### PR TITLE
Create a gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.git* export-ignore
+.hg* export-ignore
+*.c diff=cpp
+*.cpp diff=cpp
+*.h diff=cpp


### PR DESCRIPTION
When creating an archive, the GitHub repository and VCS-specific files
are now ignored.
The diff "hunk header" is customized for C/C++ [1].

[1]: https://git-scm.com/docs/gitattributes#_defining_a_custom_hunk_header