### PR TITLE
Add GitHub action steps to build AppImage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   linux-os:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
     - name: Update APT
       run: sudo apt-get update
@@ -20,6 +20,26 @@ jobs:
       run: mkdir build && cd build && ../configure
     - name: Build
       run: cd build && make -j2
+    - name: Prepare appimagetool
+      run: |
+        cd build &&
+        wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool &&
+        chmod +x appimagetool &&
+        sudo apt install -y appstream
+    - name: Clone love-appimages
+      uses: actions/checkout@v2
+      with:
+        path: build/love-appimages
+        repository: pfirsich/love-appimages
+    - name: Build AppImage
+      run: |
+        cd build &&
+        python3 love-appimages/build.py .. AppDir --builddir build --appimage love.AppImage
+    - name: Artifact
+      uses: actions/upload-artifact@v2-preview
+      with:
+        name: love.AppImage
+        path: build/love.AppImage
   windows-os:
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
Note that I changed `runs-on` to Ubuntu 16.04, which might be undesired, but using latest would result in an AppImage that would be useful on way less machines.

As discussed with slime it should be fine that I am pulling a script from my pfirsich/love-appimages repository. 

Sadly the resulting artifact will be a .zip file called love.AppImage.zip that contains the AppImage, which is, for now, a restriction of the upload-artifact action: https://github.com/actions/upload-artifact/issues/3#issuecomment-598820814

See this action for an example artifact (and please verify that it works for you as well): https://github.com/pfirsich/love/actions/runs/56211949