### PR TITLE
Make getTime() relative to first invocation

### DIFF
--- a/src/modules/timer/Timer.cpp
+++ b/src/modules/timer/Timer.cpp
@@ -24,6 +24,7 @@
 #include "common/delay.h"
 #include "Timer.h"
 
+#include <iostream>
 #if defined(LOVE_WINDOWS)
 #include <windows.h>
 #elif defined(LOVE_MACOSX) || defined(LOVE_IOS)
@@ -134,11 +135,10 @@ double Timer::getTime()
 {
 	static const timespec start = getTimeAbsolute();
 	const timespec now = getTimeAbsolute();
-	const timespec rel = timespec {
-		now.tv_sec - start.tv_sec,
-		now.tv_nsec - start.tv_nsec
-	};
-	return (double) rel.tv_sec + (double) rel.tv_nsec / 1.0e9;
+	// tv_sec and tv_nsec should be signed on POSIX, so we are fine in just subtracting here.
+	const long sec = now.tv_sec - start.tv_sec;
+	const long nsec = now.tv_nsec - start.tv_nsec;
+	return (double) sec + (double) nsec / 1.0e9;
 }
 
 #elif defined(LOVE_MACOSX) || defined(LOVE_IOS)

--- a/src/modules/timer/Timer.cpp
+++ b/src/modules/timer/Timer.cpp
@@ -182,7 +182,7 @@ double Timer::getTime()
 	const LARGE_INTEGER now = getTimeAbsolute();
 	LARGE_INTEGER rel;
 	rel.QuadPart = now.QuadPart - start.QuadPart;
-	return rel.QuadPart / freq.QuadPart;
+	return (double) rel.QuadPart / (double) freq.QuadPart;
 }
 
 #endif

--- a/src/modules/timer/Timer.cpp
+++ b/src/modules/timer/Timer.cpp
@@ -35,15 +35,6 @@
 #include <sys/time.h>
 #endif
 
-#if defined(LOVE_LINUX)
-static inline double getTimeOfDay()
-{
-	timeval t;
-	gettimeofday(&t, NULL);
-	return (double) t.tv_sec + (double) t.tv_usec / 1000000.0;
-}
-#endif
-
 namespace love
 {
 namespace timer
@@ -109,58 +100,92 @@ double Timer::getAverageDelta() const
 	return averageDelta;
 }
 
-double Timer::getTimerPeriod()
+#if defined(LOVE_LINUX)
+
+static inline timespec getTimeOfDay()
 {
-#if defined(LOVE_MACOSX) || defined(LOVE_IOS)
-	mach_timebase_info_data_t info;
-	mach_timebase_info(&info);
-	return (double) info.numer / (double) info.denom / 1000000000.0;
-#elif defined(LOVE_WINDOWS)
-	LARGE_INTEGER temp;
-	if (QueryPerformanceFrequency(&temp) != 0 && temp.QuadPart != 0)
-		return 1.0 / (double) temp.QuadPart;
-#endif
-	return 0;
+	timeval t;
+	gettimeofday(&t, NULL);
+	return timespec { t.tv_sec, t.tv_usec * 1000 };
 }
 
-double Timer::getTimeAbsolute()
+static timespec getTimeAbsolute()
 {
-	// The timer period (reciprocal of the frequency.)
-	static const double timerPeriod = getTimerPeriod();
-
-#if defined(LOVE_LINUX)
-	(void) timerPeriod; // Unused on linux
-
-	double mt;
 	// Check for POSIX timers and monotonic clocks. If not supported, use the gettimeofday fallback.
 #if _POSIX_TIMERS > 0 && defined(_POSIX_MONOTONIC_CLOCK) \
 && (defined(CLOCK_MONOTONIC_RAW) || defined(CLOCK_MONOTONIC))
-	timespec t;
+
 #ifdef CLOCK_MONOTONIC_RAW
 	clockid_t clk_id = CLOCK_MONOTONIC_RAW;
 #else
 	clockid_t clk_id = CLOCK_MONOTONIC;
 #endif
+
+	timespec t;
 	if (clock_gettime(clk_id, &t) == 0)
-		mt = (double) t.tv_sec + (double) t.tv_nsec / 1000000000.0;
+		return t;
 	else
+		return getTimeOfDay();
 #endif
-		mt = getTimeOfDay();
-	return mt;
-#elif defined(LOVE_MACOSX) || defined(LOVE_IOS)
-	return (double) mach_absolute_time() * timerPeriod;
-#elif defined(LOVE_WINDOWS)
-	LARGE_INTEGER microTime;
-	QueryPerformanceCounter(&microTime);
-	return (double) microTime.QuadPart * timerPeriod;
-#endif
+	return getTimeOfDay();
 }
 
 double Timer::getTime()
 {
-	static const double start = getTimeAbsolute();
-	return getTimeAbsolute() - start;
+	static const timespec start = getTimeAbsolute();
+	const timespec now = getTimeAbsolute();
+	const timespec rel = timespec {
+		now.tv_sec - start.tv_sec,
+		now.tv_nsec - start.tv_nsec
+	};
+	return (double) rel.tv_sec + (double) rel.tv_nsec / 1.0e9;
 }
+
+#elif defined(LOVE_MACOSX) || defined(LOVE_IOS)
+
+static mach_timebase_info_data_t getTimebaseInfo()
+{
+	mach_timebase_info_data_t info;
+	mach_timebase_info(&info);
+	return info;
+}
+
+double Timer::getTime()
+{
+	static const mach_timebase_info_data_t info = getTimebaseInfo();
+	static const uint64_t start = mach_absolute_time();
+	const uint64_t rel = mach_absolute_time() - start;
+	return ((double) rel * 1.0e-9) * (double) info.number / (double) info.denom;
+}
+
+#elif defined(LOVE_WINDOWS)
+
+static LARGE_INTEGER getTimeAbsolute()
+{
+	LARGE_INTEGER t;
+	QueryPerformanceCounter(&t);
+	return t;
+}
+
+static LARGE_INTEGER getFrequency()
+{
+	LARGE_INTEGER freq;
+	// "On systems that run Windows XP or later, the function will always succeed and will thus never return zero."
+	QueryPerformanceFrequency(&freq);
+	return freq;
+}
+
+double Timer::getTime()
+{
+	static const LARGE_INTEGER freq = getFrequency();
+	static const LARGE_INTEGER start = getTimeAbsolute();
+	const LARGE_INTEGER now = getTimeAbsolute();
+	LARGE_INTEGER rel;
+	rel.QuadPart = now.QuadPart - start.QuadPart;
+	return rel.QuadPart / freq.QuadPart;
+}
+
+#endif
 
 } // timer
 } // love

--- a/src/modules/timer/Timer.cpp
+++ b/src/modules/timer/Timer.cpp
@@ -123,7 +123,7 @@ double Timer::getTimerPeriod()
 	return 0;
 }
 
-double Timer::getTime()
+double Timer::getTimeAbsolute()
 {
 	// The timer period (reciprocal of the frequency.)
 	static const double timerPeriod = getTimerPeriod();
@@ -154,6 +154,12 @@ double Timer::getTime()
 	QueryPerformanceCounter(&microTime);
 	return (double) microTime.QuadPart * timerPeriod;
 #endif
+}
+
+double Timer::getTime()
+{
+	static const double start = getTimeAbsolute();
+	return getTimeAbsolute() - start;
 }
 
 } // timer

--- a/src/modules/timer/Timer.h
+++ b/src/modules/timer/Timer.h
@@ -72,9 +72,10 @@ public:
 	double getAverageDelta() const;
 
 	/**
-	 * Gets the amount of time passed since an unspecified time. Useful for
-	 * profiling code or measuring intervals. The time is microsecond-precise,
-	 * and increases monotonically.
+	 * Gets the amount of time in seconds passed since its first invocation
+	 * (which happens as part of Timer::step at the start of love.run).
+	 * Useful for profiling code or measuring intervals.
+	 * The time is microsecond-precise, and increases monotonically.
 	 * @return The time (in seconds)
 	 **/
 	static double getTime();
@@ -101,6 +102,9 @@ private:
 
 	// Returns the timer period on some platforms.
 	static double getTimerPeriod();
+
+	// Like getTime, but relative to an unspecified time.
+	static double getTimeAbsolute();
 
 }; // Timer
 

--- a/src/modules/timer/Timer.h
+++ b/src/modules/timer/Timer.h
@@ -101,12 +101,6 @@ private:
 	// The current timestep.
 	double dt;
 
-	// Returns the timer period on some platforms.
-	static double getTimerPeriod();
-
-	// Like getTime, but relative to an unspecified time.
-	static double getTimeAbsolute();
-
 }; // Timer
 
 } // timer

--- a/src/modules/timer/Timer.h
+++ b/src/modules/timer/Timer.h
@@ -73,7 +73,8 @@ public:
 
 	/**
 	 * Gets the amount of time in seconds passed since its first invocation
-	 * (which happens as part of Timer::step at the start of love.run).
+	 * (which happens as part of the Timer constructor,
+	 * which is called when the module is first opened).
 	 * Useful for profiling code or measuring intervals.
 	 * The time is microsecond-precise, and increases monotonically.
 	 * @return The time (in seconds)


### PR DESCRIPTION
As we have talked about a bit on the Discord server, I made getTimer relative to it's first invocation (which happens at the start of love.run), so that there are less precision issues (and also more predictable behaviour).
I did some investigation of whether, if starting from 0, floats would be enough for most tasks and according to the godbolt I shared on the server too (https://godbolt.org/z/M4HadW) it seems that even for a week of runtime, the precision is still pretty good.
I did take a minute or two to understand all the macro stuff to handle the different platforms and moved some stuff around to make it easier to understand, but I realize this could possibly be a change too big to justify the little feature impact, so if you don't like it, I can change that back.
I tested by printing love.time.getTime() in love.load to the console and to the screen in love.draw and it seems the first value returned is about 0.2 on my system, so maybe the first call is not in love.run. I don't think that's a problem per se, but it might make my comments inaccurate.
I also ran a random program I was also working on and that worked fine. Maybe more testing should be done?