### PR TITLE
Add Body.getKinematicState and Body.setKinematicState

### DIFF
--- a/src/modules/physics/box2d/Body.cpp
+++ b/src/modules/physics/box2d/Body.cpp
@@ -112,7 +112,7 @@ float Body::getAngularVelocity() const
 	return body->GetAngularVelocity();
 }
 
-void Body::getState(b2Vec2 &pos_o, float &a_o, b2Vec2 &vel_o, float &da_o) const
+void Body::getKinematicState(b2Vec2 &pos_o, float &a_o, b2Vec2 &vel_o, float &da_o) const
 {
 	pos_o = Physics::scaleUp(body->GetPosition());
 	a_o = body->GetAngle();
@@ -233,7 +233,7 @@ void Body::setAngularVelocity(float r)
 	body->SetAngularVelocity(r);
 }
 
-void Body::setState(b2Vec2 pos, float a, b2Vec2 vel, float da)
+void Body::setKinematicState(b2Vec2 pos, float a, b2Vec2 vel, float da)
 {
 	body->SetTransform(Physics::scaleDown(pos), a);
 	body->SetLinearVelocity(Physics::scaleDown(vel));

--- a/src/modules/physics/box2d/Body.cpp
+++ b/src/modules/physics/box2d/Body.cpp
@@ -112,6 +112,14 @@ float Body::getAngularVelocity() const
 	return body->GetAngularVelocity();
 }
 
+void Body::getState(b2Vec2 &pos_o, float &a_o, b2Vec2 &vel_o, float &da_o) const
+{
+	pos_o = Physics::scaleUp(body->GetPosition());
+	a_o = body->GetAngle();
+	vel_o = Physics::scaleUp(body->GetLinearVelocity());
+	da_o = body->GetAngularVelocity();
+}
+
 float Body::getMass() const
 {
 	return body->GetMass();
@@ -223,6 +231,13 @@ void Body::setAngle(float d)
 void Body::setAngularVelocity(float r)
 {
 	body->SetAngularVelocity(r);
+}
+
+void Body::setState(b2Vec2 pos, float a, b2Vec2 vel, float da)
+{
+	body->SetTransform(Physics::scaleDown(pos), a);
+	body->SetLinearVelocity(Physics::scaleDown(vel));
+	body->SetAngularVelocity(da);
 }
 
 void Body::setPosition(float x, float y)

--- a/src/modules/physics/box2d/Body.h
+++ b/src/modules/physics/box2d/Body.h
@@ -130,6 +130,11 @@ public:
 	float getAngularVelocity() const;
 
 	/**
+	 * Get the current Body kinematic state. (Position, angle, velocity, angle velocity).
+	 **/
+	void getState(b2Vec2 &pos_o, float &a_o, b2Vec2& vel_o, float &da_o) const;
+
+	/**
 	 * Gets the Body's mass.
 	 **/
 	float getMass() const;
@@ -218,6 +223,11 @@ public:
 	 * Sets the current spin of the Body.
 	 **/
 	void setAngularVelocity(float r);
+
+	/**
+	 * Set the current Body kinematic state. (Position, angle, velocity, angle velocity).
+	 **/
+	void setState(b2Vec2 pos, float a, b2Vec2 vel, float da);
 
 	/**
 	 * Sets the current position of the Body.

--- a/src/modules/physics/box2d/Body.h
+++ b/src/modules/physics/box2d/Body.h
@@ -132,7 +132,7 @@ public:
 	/**
 	 * Get the current Body kinematic state. (Position, angle, velocity, angle velocity).
 	 **/
-	void getState(b2Vec2 &pos_o, float &a_o, b2Vec2& vel_o, float &da_o) const;
+	void getKinematicState(b2Vec2 &pos_o, float &a_o, b2Vec2& vel_o, float &da_o) const;
 
 	/**
 	 * Gets the Body's mass.
@@ -227,7 +227,7 @@ public:
 	/**
 	 * Set the current Body kinematic state. (Position, angle, velocity, angle velocity).
 	 **/
-	void setState(b2Vec2 pos, float a, b2Vec2 vel, float da);
+	void setKinematicState(b2Vec2 pos, float a, b2Vec2 vel, float da);
 
 	/**
 	 * Sets the current position of the Body.

--- a/src/modules/physics/box2d/wrap_Body.cpp
+++ b/src/modules/physics/box2d/wrap_Body.cpp
@@ -125,6 +125,21 @@ int w_Body_getAngularVelocity(lua_State *L)
 	return 1;
 }
 
+int w_Body_getState(lua_State *L)
+{
+	Body *t = luax_checkbody(L, 1);
+	b2Vec2 pos_o, vel_o;
+	float a_o, da_o;
+	t->getState(pos_o, a_o, vel_o, da_o);
+	lua_pushnumber(L, pos_o.x);
+	lua_pushnumber(L, pos_o.y);
+	lua_pushnumber(L, a_o);
+	lua_pushnumber(L, vel_o.x);
+	lua_pushnumber(L, vel_o.y);
+	lua_pushnumber(L, da_o);
+	return 6;
+}
+
 int w_Body_getMass(lua_State *L)
 {
 	Body *t = luax_checkbody(L, 1);
@@ -310,6 +325,19 @@ int w_Body_setPosition(lua_State *L)
 	float arg1 = (float)luaL_checknumber(L, 2);
 	float arg2 = (float)luaL_checknumber(L, 3);
 	luax_catchexcept(L, [&](){ t->setPosition(arg1, arg2); });
+	return 0;
+}
+
+int w_Body_setState(lua_State *L)
+{
+	Body *t = luax_checkbody(L, 1);
+	float x = (float)luaL_checknumber(L, 2);
+	float y = (float)luaL_checknumber(L, 3);
+	float a = (float)luaL_checknumber(L, 4);
+	float dx = (float)luaL_checknumber(L, 5);
+	float dy = (float)luaL_checknumber(L, 6);
+	float da = (float)luaL_checknumber(L, 7);
+	luax_catchexcept(L, [&](){ t->setState(b2Vec2(x, y), a, b2Vec2(dx, dy), da); });
 	return 0;
 }
 
@@ -631,6 +659,7 @@ static const luaL_Reg w_Body_functions[] =
 	{ "getWorldCenter", w_Body_getWorldCenter },
 	{ "getLocalCenter", w_Body_getLocalCenter },
 	{ "getAngularVelocity", w_Body_getAngularVelocity },
+	{ "getState", w_Body_getState },
 	{ "getMass", w_Body_getMass },
 	{ "getInertia", w_Body_getInertia },
 	{ "getMassData", w_Body_getMassData },
@@ -648,6 +677,7 @@ static const luaL_Reg w_Body_functions[] =
 	{ "setAngle", w_Body_setAngle },
 	{ "setAngularVelocity", w_Body_setAngularVelocity },
 	{ "setPosition", w_Body_setPosition },
+	{ "setState", w_Body_setState },
 	{ "resetMassData", w_Body_resetMassData },
 	{ "setMassData", w_Body_setMassData },
 	{ "setMass", w_Body_setMass },

--- a/src/modules/physics/box2d/wrap_Body.cpp
+++ b/src/modules/physics/box2d/wrap_Body.cpp
@@ -125,12 +125,12 @@ int w_Body_getAngularVelocity(lua_State *L)
 	return 1;
 }
 
-int w_Body_getState(lua_State *L)
+int w_Body_getKinematicState(lua_State *L)
 {
 	Body *t = luax_checkbody(L, 1);
 	b2Vec2 pos_o, vel_o;
 	float a_o, da_o;
-	t->getState(pos_o, a_o, vel_o, da_o);
+	t->getKinematicState(pos_o, a_o, vel_o, da_o);
 	lua_pushnumber(L, pos_o.x);
 	lua_pushnumber(L, pos_o.y);
 	lua_pushnumber(L, a_o);
@@ -328,7 +328,7 @@ int w_Body_setPosition(lua_State *L)
 	return 0;
 }
 
-int w_Body_setState(lua_State *L)
+int w_Body_setKinematicState(lua_State *L)
 {
 	Body *t = luax_checkbody(L, 1);
 	float x = (float)luaL_checknumber(L, 2);
@@ -337,7 +337,7 @@ int w_Body_setState(lua_State *L)
 	float dx = (float)luaL_checknumber(L, 5);
 	float dy = (float)luaL_checknumber(L, 6);
 	float da = (float)luaL_checknumber(L, 7);
-	luax_catchexcept(L, [&](){ t->setState(b2Vec2(x, y), a, b2Vec2(dx, dy), da); });
+	luax_catchexcept(L, [&](){ t->setKinematicState(b2Vec2(x, y), a, b2Vec2(dx, dy), da); });
 	return 0;
 }
 
@@ -659,7 +659,7 @@ static const luaL_Reg w_Body_functions[] =
 	{ "getWorldCenter", w_Body_getWorldCenter },
 	{ "getLocalCenter", w_Body_getLocalCenter },
 	{ "getAngularVelocity", w_Body_getAngularVelocity },
-	{ "getState", w_Body_getState },
+	{ "getKinematicState", w_Body_getKinematicState },
 	{ "getMass", w_Body_getMass },
 	{ "getInertia", w_Body_getInertia },
 	{ "getMassData", w_Body_getMassData },
@@ -677,7 +677,7 @@ static const luaL_Reg w_Body_functions[] =
 	{ "setAngle", w_Body_setAngle },
 	{ "setAngularVelocity", w_Body_setAngularVelocity },
 	{ "setPosition", w_Body_setPosition },
-	{ "setState", w_Body_setState },
+	{ "setKinematicState", w_Body_setKinematicState },
 	{ "resetMassData", w_Body_resetMassData },
 	{ "setMassData", w_Body_setMassData },
 	{ "setMass", w_Body_setMass },


### PR DESCRIPTION
Allows getting/setting a body's full kinematic state in a single call. My use case is

```lua
function myentity:think()
    self.x, self.y, self.a, self.dx, self.dy, self.da = self.body:getState()
    ...
end
```