### PR TITLE
SoundData:copyFrom() and SoundData:slice()

### DIFF
--- a/src/modules/sound/SoundData.cpp
+++ b/src/modules/sound/SoundData.cpp
@@ -276,7 +276,7 @@ void SoundData::copyFrom(const SoundData *src, int srcStart, int count, int dstS
 	{
 		// Bit depth mismatch, use get/setSample at loop
 		for (int i = 0; i < count * channels; i++)
-			setSample(dstStart + i, src->getSample(srcStart + i));
+			setSample(dstStart * channels + i, src->getSample(srcStart * channels + i));
 	}
 	else if (this->data == src->data)
 		// May overlap, use memmove

--- a/src/modules/sound/SoundData.cpp
+++ b/src/modules/sound/SoundData.cpp
@@ -98,7 +98,7 @@ SoundData::SoundData(int samples, int sampleRate, int bitDepth, int channels)
 	load(samples, sampleRate, bitDepth, channels);
 }
 
-SoundData::SoundData(void *d, int samples, int sampleRate, int bitDepth, int channels)
+SoundData::SoundData(const void *d, int samples, int sampleRate, int bitDepth, int channels)
 	: data(0)
 	, size(0)
 	, sampleRate(0)
@@ -129,7 +129,7 @@ SoundData *SoundData::clone() const
 	return new SoundData(*this);
 }
 
-void SoundData::load(int samples, int sampleRate, int bitDepth, int channels, void *newData)
+void SoundData::load(int samples, int sampleRate, int bitDepth, int channels, const void *newData)
 {
 	if (samples <= 0)
 		throw love::Exception("Invalid sample count: %d", samples);
@@ -283,6 +283,21 @@ void SoundData::copyFrom(const SoundData *src, int srcStart, int count, int dstS
 		memmove(data + dstStart * bytesPerSample, src->data + srcStart * bytesPerSample, count * bytesPerSample);
 	else
 		memcpy(data + dstStart * bytesPerSample, src->data + srcStart * bytesPerSample, count * bytesPerSample);
+}
+
+SoundData *SoundData::slice(int start, int length) const
+{
+	int totalSamples = getSampleCount();
+
+	if (length == 0)
+		throw love::Exception("Invalid slice length: 0");
+	else if (length < 0)
+		length = totalSamples - start;
+
+	if (start < 0 || start + length > totalSamples)
+		throw love::Exception("Attempt to slice at out-of-range position!");
+
+	return new SoundData(data + start * channels * bitDepth/8, length, sampleRate, bitDepth, channels);
 }
 
 } // sound

--- a/src/modules/sound/SoundData.cpp
+++ b/src/modules/sound/SoundData.cpp
@@ -267,9 +267,9 @@ void SoundData::copyFrom(const SoundData *src, int srcStart, int count, int dstS
 	size_t srcBytesPerSample = (size_t) src->channels * src->bitDepth/8;
 	
 	// Check range
-	if (dstStart < 0 || (dstStart+count) * bytesPerSample >= size)
+	if (dstStart < 0 || (dstStart+count) * bytesPerSample > size)
 		throw love::Exception("Destination out-of-range!");
-	if (srcStart < 0 || (srcStart+count) * srcBytesPerSample >= src->size)
+	if (srcStart < 0 || (srcStart+count) * srcBytesPerSample > src->size)
 		throw love::Exception("Source out-of-range!");
 
 	if (bitDepth != src->bitDepth)

--- a/src/modules/sound/SoundData.h
+++ b/src/modules/sound/SoundData.h
@@ -61,6 +61,8 @@ public:
 	float getSample(int i) const;
 	float getSample(int i, int channel) const;
 
+	void copyFrom(const SoundData *src, int srcStart, int count, int dstStart);
+
 private:
 
 	void load(int samples, int sampleRate, int bitDepth, int channels, void *newData = 0);

--- a/src/modules/sound/SoundData.h
+++ b/src/modules/sound/SoundData.h
@@ -39,7 +39,7 @@ public:
 
 	SoundData(Decoder *decoder);
 	SoundData(int samples, int sampleRate, int bitDepth, int channels);
-	SoundData(void *d, int samples, int sampleRate, int bitDepth, int channels);
+	SoundData(const void *d, int samples, int sampleRate, int bitDepth, int channels);
 	SoundData(const SoundData &c);
 
 	virtual ~SoundData();
@@ -62,10 +62,11 @@ public:
 	float getSample(int i, int channel) const;
 
 	void copyFrom(const SoundData *src, int srcStart, int count, int dstStart);
+	SoundData *slice(int start, int length = -1) const;
 
 private:
 
-	void load(int samples, int sampleRate, int bitDepth, int channels, void *newData = 0);
+	void load(int samples, int sampleRate, int bitDepth, int channels, const void *newData = 0);
 
 	uint8 *data;
 	size_t size;

--- a/src/modules/sound/wrap_SoundData.cpp
+++ b/src/modules/sound/wrap_SoundData.cpp
@@ -134,6 +134,18 @@ int w_SoundData_copyFrom(lua_State *L)
 	return 0;
 }
 
+int w_SoundData_slice(lua_State *L)
+{
+	SoundData *t = luax_checksounddata(L, 1), *c = nullptr;
+	int start = (int) luaL_checkinteger(L, 2);
+	int length = (int) luaL_optinteger(L, 3, -1);
+
+	luax_catchexcept(L, [&](){ c = t->slice(start, length); });
+	luax_pushtype(L, c);
+	c->release();
+	return 1;
+}
+
 static const luaL_Reg w_SoundData_functions[] =
 {
 	{ "clone", w_SoundData_clone },
@@ -145,6 +157,7 @@ static const luaL_Reg w_SoundData_functions[] =
 	{ "setSample", w_SoundData_setSample },
 	{ "getSample", w_SoundData_getSample },
 	{ "copyFrom", w_SoundData_copyFrom },
+	{ "slice", w_SoundData_slice },
 
 	{ 0, 0 }
 };

--- a/src/modules/sound/wrap_SoundData.cpp
+++ b/src/modules/sound/wrap_SoundData.cpp
@@ -121,6 +121,19 @@ int w_SoundData_getSample(lua_State *L)
 	return 1;
 }
 
+int w_SoundData_copyFrom(lua_State *L)
+{
+	SoundData *dst = luax_checksounddata(L, 1);
+	const SoundData *src = luax_checksounddata(L, 2);
+
+	int srcStart = (int) luaL_checkinteger(L, 3);
+	int count = (int) luaL_checkinteger(L, 4);
+	int dstStart = (int) luaL_optinteger(L, 5, 0);
+
+	luax_catchexcept(L, [&](){ dst->copyFrom(src, srcStart, count, dstStart); });
+	return 0;
+}
+
 static const luaL_Reg w_SoundData_functions[] =
 {
 	{ "clone", w_SoundData_clone },
@@ -131,6 +144,7 @@ static const luaL_Reg w_SoundData_functions[] =
 	{ "getDuration", w_SoundData_getDuration },
 	{ "setSample", w_SoundData_setSample },
 	{ "getSample", w_SoundData_getSample },
+	{ "copyFrom", w_SoundData_copyFrom },
 
 	{ 0, 0 }
 };


### PR DESCRIPTION
This pull request adds 2 functions to `SoundData` object.

```c
void SoundData:copyFrom(SoundData src, number srcStart, number count, number dstStart = 0)
SoundData SoundData:slice(number start, number length = -1)
```

`SoundData:copyFrom` works similar to [`ImageData:paste`](https://love2d.org/wiki/ImageData:paste) but operates on SoundData instead. The copy operation only works if the channel count is same along with additional range checks. Note that this function does NOT perform audio mixing nor resampling (in case of sample rate mismatch), audio sample is copied as-is, or with bit-depth conversion if needed. Ideally an additional FFI implementation is also needed but I have no idea how to call `memmove` without calling `ffi.cdef` at `wrap_SoundData.lua`.

`SoundData:slice` allows user to slice existing SoundData to create smaller SoundDatas, similar to [`love.data.newDataView`](https://love2d.org/wiki/love.data.newDataView) but operates on SoundData instead of ByteData. The created SoundData has same parameters as the source except it's independent and has smaller sample count than the source. When `length` is -1, it will slice starting from `start` until the end of the source.