### PR TITLE
adds iOS audio interruption handling and recovery

### DIFF
--- a/src/common/ios.h
+++ b/src/common/ios.h
@@ -79,6 +79,12 @@ bool setAudioMixWithOthers(bool mixEnabled);
 bool hasBackgroundMusic();
 
 /**
+ * Registers notifications to handle and restore audio interruptions
+ **/
+void initAudioSessionInterruptionHandler();
+void destroyAudioSessionInterruptionHandler();
+    
+/**
  * Gets the area in the window that is safe for UI to render to (not covered by
  * the status bar, notch, etc.)
  **/

--- a/src/common/ios.mm
+++ b/src/common/ios.mm
@@ -28,6 +28,8 @@
 #import <AudioToolbox/AudioServices.h>
 #import <AVFoundation/AVFoundation.h>
 
+#include "modules/audio/Audio.h"
+
 #include <vector>
 
 #include <SDL_events.h>
@@ -199,6 +201,53 @@ static int dropFileEventFilter(void *userdata, SDL_Event *event)
 		return 1;
 	}
 }
+
+@interface LoveAudioInterruptionListener : NSObject
+@end
+
+@implementation LoveAudioInterruptionListener
+
++ (id) shared
+{
+	// thread-safe singleton
+	static dispatch_once_t pred = 0;
+	__strong static id _shared = nil;
+	dispatch_once(&pred, ^{
+			_shared = [[self alloc] init];
+		});
+	return _shared;
+}
+
+- (void)audioSessionInterruption:(NSNotification *)note
+{
+	@synchronized (self) {
+		auto audio = love::Module::getInstance<love::audio::Audio>(love::Module::M_AUDIO);
+		if (!audio) {
+			NSLog(@"LoveAudioInterruptionListener could not get love audio module");
+			return;
+		}
+		NSNumber *type = note.userInfo[AVAudioSessionInterruptionTypeKey];
+		if (type.unsignedIntegerValue == AVAudioSessionInterruptionTypeBegan) {
+			audio->pauseContext();
+		} else {
+			audio->resumeContext();
+		}
+	}
+}
+
+- (void)applicationBecameActive:(NSNotification *)note
+{
+	@synchronized (self) {
+		auto audio = love::Module::getInstance<love::audio::Audio>(love::Module::M_AUDIO);
+		if (!audio) {
+			NSLog(@"ERROR:could not get love audio module");
+			return;
+		}
+		audio->resumeContext();
+	}
+}
+
+@end
 
 namespace love
 {
@@ -374,6 +423,38 @@ bool hasBackgroundMusic()
 			return session.secondaryAudioShouldBeSilencedHint;
 		return false;
 	}
+}
+
+void initAudioSessionInterruptionHandler()
+{
+	@autoreleasepool
+	{
+		AVAudioSession *session = [AVAudioSession sharedInstance];
+		NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+
+		[center addObserver:[LoveAudioInterruptionListener shared]
+			   selector:@selector(audioSessionInterruption:)
+			       name:AVAudioSessionInterruptionNotification
+			     object:session];
+
+		// An interruption end notification is not guaranteed to be sent if
+		// we were previously interrupted... resuming if needed when the app
+		// becomes active seems to be the way to go.
+		[center addObserver:[LoveAudioInterruptionListener shared]
+			   selector:@selector(applicationBecameActive:)
+			       name:UIApplicationDidBecomeActiveNotification
+			     object:nil];
+
+		[center addObserver:[LoveAudioInterruptionListener shared]
+			   selector:@selector(applicationBecameActive:)
+			       name:UIApplicationWillEnterForegroundNotification
+			     object:nil];
+	}
+}
+
+void destroyAudioSessionInterruptionHandler()
+{
+	[[NSNotificationCenter defaultCenter] removeObserver:[LoveAudioInterruptionListener shared]];
 }
 
 Rect getSafeArea(SDL_Window *window)

--- a/src/modules/audio/Audio.h
+++ b/src/modules/audio/Audio.h
@@ -291,6 +291,12 @@ public:
 	 **/
 	static bool setMixWithSystem(bool mix);
 
+	/**
+	 * Pause/resume audio context
+	 */
+	virtual void pauseContext() = 0;
+	virtual void resumeContext() = 0;
+
 private:
 
 	static StringMap<DistanceModel, DISTANCE_MAX_ENUM>::Entry distanceModelEntries[];

--- a/src/modules/audio/null/Audio.cpp
+++ b/src/modules/audio/null/Audio.cpp
@@ -203,6 +203,15 @@ bool Audio::isEFXsupported() const
 	return false;
 }
 
+void Audio::pauseContext()
+{
+}
+
+void Audio::resumeContext()
+{
+}
+
+
 } // null
 } // audio
 } // love

--- a/src/modules/audio/null/Audio.h
+++ b/src/modules/audio/null/Audio.h
@@ -86,6 +86,9 @@ public:
 	int getMaxSourceEffects() const;
 	bool isEFXsupported() const;
 
+	void pauseContext();
+	void resumeContext();
+
 private:
 	float volume;
 	DistanceModel distanceModel;

--- a/src/modules/audio/openal/Audio.cpp
+++ b/src/modules/audio/openal/Audio.cpp
@@ -26,6 +26,10 @@
 #include <cstdlib>
 #include <iostream>
 
+#ifdef LOVE_IOS
+#include "common/ios.h"
+#endif
+
 namespace love
 {
 namespace audio
@@ -189,10 +193,18 @@ Audio::Audio()
 
 	poolThread = new PoolThread(pool);
 	poolThread->start();
+	
+#ifdef LOVE_IOS
+	love::ios::initAudioSessionInterruptionHandler();
+#endif
+        
 }
 
 Audio::~Audio()
 {
+#ifdef LOVE_IOS
+	love::ios::destroyAudioSessionInterruptionHandler();
+#endif
 	poolThread->setFinish();
 	poolThread->wait();
 
@@ -291,6 +303,17 @@ void Audio::pause(const std::vector<love::audio::Source*> &sources)
 std::vector<love::audio::Source*> Audio::pause()
 {
 	return Source::pause(pool);
+}
+
+void Audio::pauseContext()
+{
+	alcMakeContextCurrent(nullptr);
+}
+
+void Audio::resumeContext()
+{
+	if (context && alcGetCurrentContext() != context)
+		alcMakeContextCurrent(context);
 }
 
 void Audio::setVolume(float volume)

--- a/src/modules/audio/openal/Audio.h
+++ b/src/modules/audio/openal/Audio.h
@@ -95,6 +95,8 @@ public:
 	void pause(love::audio::Source *source);
 	void pause(const std::vector<love::audio::Source*> &sources);
 	std::vector<love::audio::Source*> pause();
+	void pauseContext();
+	void resumeContext();
 	void setVolume(float volume);
 	float getVolume() const;
 


### PR DESCRIPTION
iOS audio interruptions (eg. alarm, or phone call ringer) disable the OpenAL context. 
This code handles the interruptions and restores the OpenAL context when the interrupt ends or the application is brought to the foreground. 

NOTE: I'm not happy with adding two methods to the Audio class to pause/restore the OpenAL context. Maybe you can think of a more elegant way to do it. 
