### PR TITLE
Disable GL_EXT_texture_array on OpenGL ES 2.0

### DIFF
--- a/src/modules/graphics/opengl/OpenGL.cpp
+++ b/src/modules/graphics/opengl/OpenGL.cpp
@@ -391,15 +391,23 @@ void OpenGL::initOpenGLFunctions()
 		}
 	}
 
-	if (GLAD_ES_VERSION_2_0 && GLAD_OES_texture_3D && !GLAD_ES_VERSION_3_0)
+	if (GLAD_ES_VERSION_2_0 && !GLAD_ES_VERSION_3_0)
 	{
-		// Function signatures don't match, we'll have to conditionally call it
-		//fp_glTexImage3D = fp_glTexImage3DOES;
-		fp_glTexSubImage3D = fp_glTexSubImage3DOES;
-		fp_glCopyTexSubImage3D = fp_glCopyTexSubImage3DOES;
-		fp_glCompressedTexImage3D = fp_glCompressedTexImage3DOES;
-		fp_glCompressedTexSubImage3D = fp_glCompressedTexSubImage3DOES;
-		fp_glFramebufferTexture3D = fp_glFramebufferTexture3DOES;
+		// The Nvidia Tegra 3 driver (used by Ouya) claims to support GL_EXT_texture_array but
+		// segfaults if you actually try to use it. OpenGL ES 2.0 devices should use OES_texture_3D.
+		// GL_EXT_texture_array is for desktops.
+		GLAD_EXT_texture_array = false;
+
+		if (GLAD_OES_texture_3D)
+		{
+			// Function signatures don't match, we'll have to conditionally call it
+			//fp_glTexImage3D = fp_glTexImage3DOES;
+			fp_glTexSubImage3D = fp_glTexSubImage3DOES;
+			fp_glCopyTexSubImage3D = fp_glCopyTexSubImage3DOES;
+			fp_glCompressedTexImage3D = fp_glCompressedTexImage3DOES;
+			fp_glCompressedTexSubImage3D = fp_glCompressedTexSubImage3DOES;
+			fp_glFramebufferTexture3D = fp_glFramebufferTexture3DOES;
+		}
 	}
 
 	if (!GLAD_VERSION_3_2 && !GLAD_ES_VERSION_3_2 && !GLAD_ARB_draw_elements_base_vertex)

--- a/src/modules/graphics/wrap_GraphicsShader.lua
+++ b/src/modules/graphics/wrap_GraphicsShader.lua
@@ -54,7 +54,8 @@ GLSL.SYNTAX = [[
 	#define DepthCubeImage samplerCubeShadow
 #endif
 #define extern uniform
-#ifdef GL_EXT_texture_array
+#if defined(GL_EXT_texture_array) && (!defined(GL_ES) || __VERSION__ > 100)
+#define texture_arrays_enabled
 #extension GL_EXT_texture_array : enable
 #endif
 #ifdef GL_OES_texture_3D
@@ -85,7 +86,7 @@ uniform LOVE_HIGHP_OR_MEDIUMP vec4 love_ScreenSize;
 
 GLSL.FUNCTIONS = [[
 #ifdef GL_ES
-	#if __VERSION__ >= 300 || defined(GL_EXT_texture_array)
+	#if __VERSION__ >= 300 || defined(texture_arrays_enabled)
 		precision lowp sampler2DArray;
 	#endif
 	#if __VERSION__ >= 300 || defined(GL_OES_texture_3D)
@@ -121,7 +122,7 @@ GLSL.FUNCTIONS = [[
 	#if __VERSION__ > 100 || defined(GL_OES_texture_3D)
 		vec4 Texel(sampler3D s, vec3 c) { return love_texture3D(s, c); }
 	#endif
-	#if __VERSION__ >= 130 || defined(GL_EXT_texture_array)
+	#if __VERSION__ >= 130 || defined(texture_arrays_enabled)
 		vec4 Texel(sampler2DArray s, vec3 c) { return love_texture2DArray(s, c); }
 	#endif
 	#ifdef PIXEL
@@ -130,7 +131,7 @@ GLSL.FUNCTIONS = [[
 		#if __VERSION__ > 100 || defined(GL_OES_texture_3D)
 			vec4 Texel(sampler3D s, vec3 c, float b) { return love_texture3D(s, c, b); }
 		#endif
-		#if __VERSION__ >= 130 || defined(GL_EXT_texture_array)
+		#if __VERSION__ >= 130 || defined(texture_arrays_enabled)
 			vec4 Texel(sampler2DArray s, vec3 c, float b) { return love_texture2DArray(s, c, b); }
 		#endif
 	#endif


### PR DESCRIPTION
The Nvidia Tegra 3 driver for Android (used by Ouya) erroneously claims
to support the desktop-oriented GL_EXT_texture_array extension. On
desktop GPUs using (non ES) OpenGL, the glTexImage3D and similar
functions are always present, and the GL_EXT_texture_array extension
simply adds support for texture arrays to those functions. On OpenGL ES
2.0, those functions do not exist, and GL_OES_texture_3D is required to
define them.

Calling glTexImage3D on the Tegra 3 causes a segfault. This change works
around the issue by manually setting GLAD_EXT_texture_array to 0 on
OpenGL ES 2.0 systems, which causes LÖVE to avoid codepaths that assume
that the 3D texture functions are available. It doesn't make sense for
any OpenGL ES 2.0 GPU to claim support for GL_EXT_texture_array.

Fixes #1647