### PR TITLE
Fix #1641: add love.graphics.buildTransform()

### DIFF
--- a/src/modules/graphics/Graphics.cpp
+++ b/src/modules/graphics/Graphics.cpp
@@ -1700,6 +1700,15 @@ void Graphics::origin()
 	pixelScaleStack.back() = 1;
 }
 
+love::math::Transform *Graphics::buildTransform()
+{
+	Matrix4 &m = transformStack.back();
+
+	love::math::Transform *t = new love::math::Transform();
+	t->setMatrix(m);
+	return t;
+}
+
 void Graphics::applyTransform(love::math::Transform *transform)
 {
 	Matrix4 &m = transformStack.back();

--- a/src/modules/graphics/Graphics.cpp
+++ b/src/modules/graphics/Graphics.cpp
@@ -1702,11 +1702,8 @@ void Graphics::origin()
 
 love::math::Transform *Graphics::buildTransform()
 {
-	Matrix4 &m = transformStack.back();
-
-	love::math::Transform *t = new love::math::Transform();
-	t->setMatrix(m);
-	return t;
+	const Matrix4 &m = transformStack.back();
+	return new love::math::Transform(m);
 }
 
 void Graphics::applyTransform(love::math::Transform *transform)

--- a/src/modules/graphics/Graphics.h
+++ b/src/modules/graphics/Graphics.h
@@ -862,6 +862,7 @@ public:
 	void shear(float kx, float ky);
 	void origin();
 
+	love::math::Transform *buildTransform();
 	void applyTransform(love::math::Transform *transform);
 	void replaceTransform(love::math::Transform *transform);
 

--- a/src/modules/graphics/wrap_Graphics.cpp
+++ b/src/modules/graphics/wrap_Graphics.cpp
@@ -2868,6 +2868,14 @@ int w_origin(lua_State * /*L*/)
 	return 0;
 }
 
+int w_buildTransform(lua_State *L)
+{
+	math::Transform *t = instance()->buildTransform();
+	luax_pushtype(L, t);
+	t->release();
+	return 1;
+}
+
 int w_applyTransform(lua_State *L)
 {
 	math::Transform *t = math::luax_checktransform(L, 1);
@@ -3025,6 +3033,7 @@ static const luaL_Reg functions[] =
 	{ "translate", w_translate },
 	{ "shear", w_shear },
 	{ "origin", w_origin },
+	{ "buildTransform", w_buildTransform },
 	{ "applyTransform", w_applyTransform },
 	{ "replaceTransform", w_replaceTransform },
 	{ "transformPoint", w_transformPoint },


### PR DESCRIPTION
This pull request fixes #1641.

This is my first contribution so please nitpick as much as possible — I appreciate all feedback :)

Even if #1641 is not an acceptable feature request I would still love feedback on the implementation!

**Naming**

I called it `buildTransform` instead of `getTransform` because I didn't want users to think that modifying the transform returned by this function would persist those changes in the graphics state.

Additionally, I've tested I can confirm my changes do not persist transform changes to the graphics state. This is because `love::math::Transform->matrix` is of type `Matrix4` and not `Matrix4&`.

**Testing**

<details><summary>I used this Lua script to test my changes</summary>

Keybinds:

- <kbd>arrow_left</kbd>: move left
- <kbd>arrow_right</kbd>: move right
- <kbd>arrow_up</kbd>: move up
- <kbd>arrow_dow </kbd>: move down
- <kbd>-</kbd>: scaleX down
- <kbd>=</kbd>: scaleX up
- <kbd>[</kbd>: scaleY down
- <kbd>]</kbd>: scaleY up
- <kbd>a</kbd>: rotate left
- <kbd>d</kbd>: rotate left

```lua
local transform

function buildExampleTransform()
    local rectwidth = 100
    local rectheight = 100
    return love.math.newTransform(
        100, 100,
        math.pi/4,
        1, 1,
        rectwidth / 2, rectheight / 2
    )
end

function love.load()
    love.graphics.setBackgroundColor(0, 255, 255)

    transform = buildExampleTransform()
end


local trX, trY = 0, 0
local scaleX, scaleY = 1, 1
local rotate = 0

function love.keypressed(key, _scancode, _isrepeat)
    if key == "-" then
        scaleX = scaleX - 0.5
    elseif key == "=" then
        scaleX = scaleX + 0.5
    end

    if key == "[" then
        scaleY = scaleY - 0.5
    elseif key == "]" then
        scaleY = scaleY + 0.5
    end

    if key == "a" then
        rotate = rotate - math.pi/8
    elseif key == "d" then
        rotate = rotate + math.pi/8
    end
end

function love.update(dt)
    if love.keyboard.isDown("right") then
        trX = trX + 25 * dt
    end
    if love.keyboard.isDown("left") then
        trX = trX - 25 * dt
    end
    if love.keyboard.isDown("up") then
        trY = trY - 25 * dt
    end
    if love.keyboard.isDown("down") then
        trY = trY + 25 * dt
    end
end

function love.draw()
    love.graphics.push()
    love.graphics.scale(scaleX, scaleY)
    love.graphics.translate(trX, trY)
    love.graphics.applyTransform(transform)
    love.graphics.rotate(rotate)
    love.graphics.setColor(0, 0, 0)
    love.graphics.print("Hello, world", 0, 0)

    local built = love.graphics.buildTransform()

    love.graphics.pop()

    debugTransform(built)
end

function debugTransform(transform)
    local matrix = {transform:getMatrix()}

    local rows = {}
    local row = {}
    for i, val in ipairs(matrix) do
        local column = (i-1) % 4
        table.insert(row, string.format("%.4f", val))

        if column == 3 then
            table.insert(rows, table.concat(row, "     "))
            row = {}
        end
    end
    love.graphics.print(table.concat(rows, "\n"))
end

```

</details>

**Potential wiki content**

```wiki

= love.graphics.buildTransform =

Returns a [[Transform]] object containing the current coordinate information which was set by [Coordinate System functions love.graphics#Coordinate_System].

== Function ==

=== Synopsis ===
<source lang="lua">
transform = love.graphics.buildTransform( )
</source>

=== Arguments ===
None.

=== Returns ===
{{param|Transform|transform|The Transform object containing the current coordinate information}}

== See Also ==
* [[parent::love.graphics]]
* [[love.math.newTransform]]
* [[love.graphics.applyTransform]]
* [[love.graphics.replaceTransform]]
* [[love.graphics.push]]
* [[love.graphics.pop]]
[[Category:Functions]]
{{#set:Description=Returns a [[Transform]] object containing the current coordinate transformation.}}
{{#set:Sub-Category=Coordinate System}}

```