### PR TITLE
Fix #1614: add Body:getLocalPoints

### DIFF
--- a/src/modules/physics/box2d/Body.cpp
+++ b/src/modules/physics/box2d/Body.cpp
@@ -346,6 +346,30 @@ void Body::getLocalVector(float x, float y, float &x_o, float &y_o)
 	y_o = v.y;
 }
 
+int Body::getLocalPoints(lua_State *L)
+{
+	int argc = lua_gettop(L);
+	int vcount = (int)argc/2;
+	// at least one point
+	love::luax_assert_argc(L, 2);
+
+	for (int i = 0; i<vcount; i++)
+	{
+		float x = (float)lua_tonumber(L, 1);
+		float y = (float)lua_tonumber(L, 2);
+		// Remove them, so we don't run out of stack space
+		lua_remove(L, 1);
+		lua_remove(L, 1);
+		// Time for scaling
+		b2Vec2 point = Physics::scaleUp(body->GetLocalPoint(Physics::scaleDown(b2Vec2(x, y))));
+		// And then we push the result
+		lua_pushnumber(L, point.x);
+		lua_pushnumber(L, point.y);
+	}
+
+	return argc;
+}
+
 void Body::getLinearVelocityFromWorldPoint(float x, float y, float &x_o, float &y_o)
 {
 	b2Vec2 v = Physics::scaleUp(body->GetLinearVelocityFromWorldPoint(Physics::scaleDown(b2Vec2(x, y))));

--- a/src/modules/physics/box2d/Body.h
+++ b/src/modules/physics/box2d/Body.h
@@ -318,6 +318,12 @@ public:
 	void getLocalVector(float x, float y, float &x_o, float &y_o);
 
 	/**
+	 * Transforms a series of points (x, y) from world coordinates
+	 * to local coordinates.
+	 **/
+	int getLocalPoints(lua_State *L);
+
+	/**
 	 * Gets the velocity on the Body for the given world point.
 	 * @param x The x-coordinate of the world point.
 	 * @param y The y-coordinate of the world point.

--- a/src/modules/physics/box2d/wrap_Body.cpp
+++ b/src/modules/physics/box2d/wrap_Body.cpp
@@ -444,6 +444,13 @@ int w_Body_getLocalVector(lua_State *L)
 	return 2;
 }
 
+int w_Body_getLocalPoints(lua_State *L)
+{
+	Body *t = luax_checkbody(L, 1);
+	lua_remove(L, 1);
+	return t->getLocalPoints(L);
+}
+
 int w_Body_getLinearVelocityFromWorldPoint(lua_State *L)
 {
 	Body *t = luax_checkbody(L, 1);
@@ -679,6 +686,7 @@ static const luaL_Reg w_Body_functions[] =
 	{ "getWorldPoints", w_Body_getWorldPoints },
 	{ "getLocalPoint", w_Body_getLocalPoint },
 	{ "getLocalVector", w_Body_getLocalVector },
+	{ "getLocalPoints", w_Body_getLocalPoints },
 	{ "getLinearVelocityFromWorldPoint", w_Body_getLinearVelocityFromWorldPoint },
 	{ "getLinearVelocityFromLocalPoint", w_Body_getLinearVelocityFromLocalPoint },
 	{ "isBullet", w_Body_isBullet },


### PR DESCRIPTION
This is identical to `Body:getWorldPoints`, except it gets the local points instead.

Fixes #1614.

I've tested this by getting 4 points in each corner around the cursor, converting those points to local points, converting those local points back into world points, and checking that the points are equal. Then using those points to draw a polygon (a square) around the cursor.

<details><summary>Lua script</summary>

```lua
local world, body

function love.load()
    love.graphics.setBackgroundColor(0, 255, 255)

    love.physics.setMeter(64)

    world = love.physics.newWorld()

    local width, height = love.window.getMode()
    body = love.physics.newBody(world, width/2, height/2)
end

function love.update(dt)
    world:update(dt)
end

function love.draw()
    love.graphics.setLineWidth(12)

    -- Build coordinates for squares around the cursor
    local mx, my = love.mouse.getPosition()
    local points = {
        mx - 30, my - 30, -- top left
        mx + 30, my - 30, -- top right
        mx + 30, my + 30, -- bottom right
        mx - 30, my + 30, -- bottom left
    }

    -- Convert those points local to the body
    local localPoints = {body:getLocalPoints(unpack(points))}

    -- Convert them back to the world
    local worldPoints = {body:getWorldPoints(unpack(localPoints))}

    -- Check that they are equal
    for i, original in ipairs(points) do
        local converted = worldPoints[i]
        assert(original == converted, string.format("Expected %f, got %f", original, converted))
    end

    -- Draw a polgyon
    love.graphics.polygon("line", unpack(worldPoints))
end
```

</details>