### PR TITLE
Remove deprecated method love.graphics.isCreated from love.errhand

### DIFF
--- a/src/scripts/boot.lua
+++ b/src/scripts/boot.lua
@@ -646,7 +646,7 @@ function love.errhand(msg)
 		return
 	end
 
-	if not love.graphics.isCreated() or not love.window.isOpen() then
+	if not love.window.isOpen() then
 		local success, status = pcall(love.window.setMode, 800, 600)
 		if not success or not status then
 			return


### PR DESCRIPTION
`love.graphics.isCreated` was removed in 0.9.0 according to the wiki.