### PR TITLE
use dt instead of inv_dt in RevoluteJoint::getMotorTorque

### DIFF
--- a/src/modules/physics/box2d/RevoluteJoint.cpp
+++ b/src/modules/physics/box2d/RevoluteJoint.cpp
@@ -101,8 +101,9 @@ float RevoluteJoint::getMotorSpeed() const
 	return joint->GetMotorSpeed();
 }
 
-float RevoluteJoint::getMotorTorque(float inv_dt) const
+float RevoluteJoint::getMotorTorque(float dt) const
 {
+	float inv_dt = 1.0f / dt;
 	return Physics::scaleUp(Physics::scaleUp(joint->GetMotorTorque(inv_dt)));
 }
 

--- a/src/modules/physics/box2d/RevoluteJoint.h
+++ b/src/modules/physics/box2d/RevoluteJoint.h
@@ -87,9 +87,9 @@ public:
 
 	/**
 	 * Get the current motor torque, usually in N-m.
-	 * @param inv_dt The inverse timestep.
+	 * @param dt The timestep.
 	 **/
-	float getMotorTorque(float inv_dt) const;
+	float getMotorTorque(float dt) const;
 
 	/**
 	 * Get the maximum motor torque, usually in N-m.

--- a/src/modules/physics/box2d/wrap_RevoluteJoint.cpp
+++ b/src/modules/physics/box2d/wrap_RevoluteJoint.cpp
@@ -91,8 +91,8 @@ int w_RevoluteJoint_getMotorSpeed(lua_State *L)
 int w_RevoluteJoint_getMotorTorque(lua_State *L)
 {
 	RevoluteJoint *t = luax_checkrevolutejoint(L, 1);
-	float inv_dt = (float)luaL_checknumber(L, 2);
-	lua_pushnumber(L, t->getMotorTorque(inv_dt));
+	float dt = (float)luaL_checknumber(L, 2);
+	lua_pushnumber(L, t->getMotorTorque(dt));
 	return 1;
 }
 


### PR DESCRIPTION
Getting `dt` from `Timer` if not provided in the call is not as straightforward as I thought (not a static method), and I don't want to fuck up my first commit in this codebase by doing something stupid.

Issue #1731