### PR TITLE
Support for per-character horizontal spacing

### DIFF
--- a/src/modules/graphics/Font.h
+++ b/src/modules/graphics/Font.h
@@ -145,6 +145,17 @@ public:
 	void getWrap(const ColoredCodepoints &codepoints, float wraplimit, std::vector<ColoredCodepoints> &lines, std::vector<int> *line_widths = nullptr);
 
 	/**
+	 * Sets the character spacing in pixel
+	 * @param spacing The new character spacing.
+	 **/
+	void setCharSpacing(float spacing);
+
+	/**
+	 * Returns the character spacing.
+	 **/
+	float getCharSpacing() const;
+
+	/**
 	 * Sets the line height (which should be a number to multiply the font size by,
 	 * example: line height = 1.2 and size = 12 means that rendered line height = 12*1.2)
 	 * @param height The new line height.
@@ -212,6 +223,7 @@ private:
 	std::vector<StrongRef<love::font::Rasterizer>> rasterizers;
 
 	int height;
+	float charSpacing;
 	float lineHeight;
 
 	int textureWidth;

--- a/src/modules/graphics/wrap_Font.cpp
+++ b/src/modules/graphics/wrap_Font.cpp
@@ -120,6 +120,21 @@ int w_Font_getWrap(lua_State *L)
 	return 2;
 }
 
+int w_Font_setCharSpacing(lua_State* L)
+{
+	Font* t = luax_checkfont(L, 1);
+	float s = (float)luaL_checknumber(L, 2);
+	t->setCharSpacing(s);
+	return 0;
+}
+
+int w_Font_getCharSpacing(lua_State* L)
+{
+	Font* t = luax_checkfont(L, 1);
+	lua_pushnumber(L, t->getCharSpacing());
+	return 1;
+}
+
 int w_Font_setLineHeight(lua_State *L)
 {
 	Font *t = luax_checkfont(L, 1);
@@ -261,6 +276,8 @@ static const luaL_Reg w_Font_functions[] =
 	{ "getHeight", w_Font_getHeight },
 	{ "getWidth", w_Font_getWidth },
 	{ "getWrap", w_Font_getWrap },
+	{ "setCharSpacing", w_Font_setCharSpacing },
+	{ "getCharSpacing", w_Font_getCharSpacing },
 	{ "setLineHeight", w_Font_setLineHeight },
 	{ "getLineHeight", w_Font_getLineHeight },
 	{ "setFilter", w_Font_setFilter },


### PR DESCRIPTION
added Font:getCharSpacing, Font:setCharSpacing
tested with love.graphics.print and Font:getWrap

character spacing is in pixel unit, negative value for letters to be shown closer
