### PR TITLE
Change luaL_loadbuffer chunkname with prefixes.

### DIFF
--- a/src/common/runtime.cpp
+++ b/src/common/runtime.cpp
@@ -985,7 +985,9 @@ void luax_runwrapper(lua_State *L, const char *filedata, size_t datalen, const c
 	// functions struct pointer as arguments.
 	if (lua_istable(L, -1))
 	{
-		luaL_loadbuffer(L, filedata, datalen, filename);
+		std::string chunkname = std::string("=[love \"") + std::string(filename) + std::string("\"]");
+
+		luaL_loadbuffer(L, filedata, datalen, chunkname.c_str());
 		lua_pushvalue(L, -2);
 		if (ffifuncs != nullptr)
 			luax_pushpointerasstring(L, ffifuncs);

--- a/src/libraries/luasocket/libluasocket/ftp.lua.h
+++ b/src/libraries/luasocket/libluasocket/ftp.lua.h
@@ -540,5 +540,5 @@ static const unsigned char B1[]={
 
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"ftp.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"ftp.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/libraries/luasocket/libluasocket/headers.lua.h
+++ b/src/libraries/luasocket/libluasocket/headers.lua.h
@@ -192,5 +192,5 @@ static const unsigned char B1[]={
 108,101,114, 34, 44, 10,125, 10, 10,114,101,116,117,114,110, 32, 95, 77,
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"headers.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"headers.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/libraries/luasocket/libluasocket/http.lua.h
+++ b/src/libraries/luasocket/libluasocket/http.lua.h
@@ -668,5 +668,5 @@ static const unsigned char B1[]={
 101,110,100, 41, 10, 10,114,101,116,117,114,110, 32, 95, 77, 10,
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"http.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"http.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/libraries/luasocket/libluasocket/ltn12.lua.h
+++ b/src/libraries/luasocket/libluasocket/ltn12.lua.h
@@ -442,5 +442,5 @@ static const unsigned char B1[]={
 110,100, 10,101,110,100, 10, 10,114,101,116,117,114,110, 32, 95, 77, 10,
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"ltn12.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"ltn12.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/libraries/luasocket/libluasocket/mbox.lua.h
+++ b/src/libraries/luasocket/libluasocket/mbox.lua.h
@@ -140,5 +140,5 @@ static const unsigned char B1[]={
 110,100, 10, 10,114,101,116,117,114,110, 32, 95, 77, 10,
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"mbox.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"mbox.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/libraries/luasocket/libluasocket/mime.lua.h
+++ b/src/libraries/luasocket/libluasocket/mime.lua.h
@@ -132,5 +132,5 @@ static const unsigned char B1[]={
 116,117,114,110, 32, 95, 77,
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"mime.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"mime.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/libraries/luasocket/libluasocket/smtp.lua.h
+++ b/src/libraries/luasocket/libluasocket/smtp.lua.h
@@ -411,5 +411,5 @@ static const unsigned char B1[]={
 110,100, 41, 10, 10,114,101,116,117,114,110, 32, 95, 77,
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"smtp.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"smtp.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/libraries/luasocket/libluasocket/socket.lua.h
+++ b/src/libraries/luasocket/libluasocket/socket.lua.h
@@ -230,5 +230,5 @@ static const unsigned char B1[]={
 116,117,114,110, 32, 95, 77, 10,
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"socket.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"socket.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/libraries/luasocket/libluasocket/tp.lua.h
+++ b/src/libraries/luasocket/libluasocket/tp.lua.h
@@ -196,5 +196,5 @@ static const unsigned char B1[]={
 114,110, 32, 95, 77, 10,
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"tp.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"tp.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/libraries/luasocket/libluasocket/url.lua.h
+++ b/src/libraries/luasocket/libluasocket/url.lua.h
@@ -563,5 +563,5 @@ static const unsigned char B1[]={
 110, 32, 95, 77, 10,
 };
 
- if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"url.lua")==0) lua_call(L, 0, LUA_MULTRET);
+ if (luaL_loadbuffer(L,(const char*)B1,sizeof(B1),"=[socket \"url.lua\"]")==0) lua_call(L, 0, LUA_MULTRET);
 }

--- a/src/modules/event/wrap_Event.cpp
+++ b/src/modules/event/wrap_Event.cpp
@@ -136,7 +136,7 @@ extern "C" int luaopen_love_event(lua_State *L)
 
 	int ret = luax_register_module(L, w);
 
-	if (luaL_loadbuffer(L, (const char *)event_lua, sizeof(event_lua), "wrap_Event.lua") == 0)
+	if (luaL_loadbuffer(L, (const char *)event_lua, sizeof(event_lua), "=[love \"wrap_Event.lua\"]") == 0)
 		lua_call(L, 0, 0);
 	else
 		lua_error(L);

--- a/src/modules/graphics/wrap_Graphics.cpp
+++ b/src/modules/graphics/wrap_Graphics.cpp
@@ -3075,12 +3075,12 @@ extern "C" int luaopen_love_graphics(lua_State *L)
 
 	int n = luax_register_module(L, w);
 
-	if (luaL_loadbuffer(L, (const char *)graphics_lua, sizeof(graphics_lua), "wrap_Graphics.lua") == 0)
+	if (luaL_loadbuffer(L, (const char *)graphics_lua, sizeof(graphics_lua), "=[love \"wrap_Graphics.lua\"]") == 0)
 		lua_call(L, 0, 0);
 	else
 		lua_error(L);
 
-	if (luaL_loadbuffer(L, (const char *)graphics_shader_lua, sizeof(graphics_shader_lua), "wrap_GraphicsShader.lua") == 0)
+	if (luaL_loadbuffer(L, (const char *)graphics_shader_lua, sizeof(graphics_shader_lua), "=[love \"wrap_GraphicsShader.lua\"]") == 0)
 		lua_call(L, 0, 0);
 	else
 		lua_error(L);

--- a/src/modules/graphics/wrap_Video.cpp
+++ b/src/modules/graphics/wrap_Video.cpp
@@ -168,7 +168,7 @@ int luaopen_video(lua_State *L)
 {
 	int ret = luax_register_type(L, &Video::type, functions, nullptr);
 
-	luaL_loadbuffer(L, video_lua, sizeof(video_lua), "Video.lua");
+	luaL_loadbuffer(L, video_lua, sizeof(video_lua), "=[love \"Video.lua\"]");
 	luax_gettypemetatable(L, Video::type);
 	lua_call(L, 1, 0);
 

--- a/src/modules/love/love.cpp
+++ b/src/modules/love/love.cpp
@@ -662,7 +662,7 @@ int w__setAccelerometerAsJoystick(lua_State *L)
 
 int luaopen_love_nogame(lua_State *L)
 {
-	if (luaL_loadbuffer(L, (const char *)love::nogame_lua, sizeof(love::nogame_lua), "nogame.lua") == 0)
+	if (luaL_loadbuffer(L, (const char *)love::nogame_lua, sizeof(love::nogame_lua), "=[love \"nogame.lua\"]") == 0)
 		lua_call(L, 0, 1);
 
 	return 1;
@@ -670,7 +670,7 @@ int luaopen_love_nogame(lua_State *L)
 
 int luaopen_love_jitsetup(lua_State *L)
 {
-	if (luaL_loadbuffer(L, jit_setup_lua, sizeof(jit_setup_lua), "jitsetup.lua") == 0)
+	if (luaL_loadbuffer(L, jit_setup_lua, sizeof(jit_setup_lua), "=[love \"jitsetup.lua\"]") == 0)
 		lua_call(L, 0, 1);
 
 	return 1;
@@ -678,7 +678,7 @@ int luaopen_love_jitsetup(lua_State *L)
 
 int luaopen_love_arg(lua_State *L)
 {
-	if (luaL_loadbuffer(L, arg_lua, sizeof(arg_lua), "arg.lua") == 0)
+	if (luaL_loadbuffer(L, arg_lua, sizeof(arg_lua), "=[love \"arg.lua\"]") == 0)
 		lua_call(L, 0, 1);
 
 	return 1;
@@ -686,7 +686,7 @@ int luaopen_love_arg(lua_State *L)
 
 int luaopen_love_callbacks(lua_State *L)
 {
-	if (luaL_loadbuffer(L, callbacks_lua, sizeof(callbacks_lua), "callbacks.lua") == 0)
+	if (luaL_loadbuffer(L, callbacks_lua, sizeof(callbacks_lua), "=[love \"callbacks.lua\"]") == 0)
 		lua_call(L, 0, 1);
 
 	return 1;
@@ -694,7 +694,7 @@ int luaopen_love_callbacks(lua_State *L)
 
 int luaopen_love_boot(lua_State *L)
 {
-	if (luaL_loadbuffer(L, boot_lua, sizeof(boot_lua), "boot.lua") == 0)
+	if (luaL_loadbuffer(L, boot_lua, sizeof(boot_lua), "=[love \"boot.lua\"]") == 0)
 		lua_call(L, 0, 1);
 
 	return 1;

--- a/src/modules/math/wrap_Math.cpp
+++ b/src/modules/math/wrap_Math.cpp
@@ -498,7 +498,7 @@ extern "C" int luaopen_love_math(lua_State *L)
 	int n = luax_register_module(L, w);
 
 	// Execute wrap_Math.lua, sending the math table and ffifuncs pointer as args.
-	luaL_loadbuffer(L, math_lua, sizeof(math_lua), "wrap_Math.lua");
+	luaL_loadbuffer(L, math_lua, sizeof(math_lua), "=[love \"wrap_Math.lua\"]");
 	lua_pushvalue(L, -2);
 	luax_pushpointerasstring(L, &ffifuncs);
 	lua_call(L, 2, 0);


### PR DESCRIPTION
LOVE's embedded script now shows as `[love "filename.lua"]` and LuaSocket's embedded script shows as `[socket "filename.lua"]`.

Fixes #1748.