### PR TITLE
Show deprecation notice when slashes is passed to require.

### DIFF
--- a/src/modules/filesystem/wrap_Filesystem.cpp
+++ b/src/modules/filesystem/wrap_Filesystem.cpp
@@ -806,6 +806,9 @@ int loader(lua_State *L)
 {
 	std::string modulename = luax_checkstring(L, 1);
 
+	if (modulename.find('/') != std::string::npos)
+		luax_markdeprecated(L, 2, "character in require string (forward slashes), use dots instead.", API_CUSTOM);
+
 	for (char &c : modulename)
 	{
 		if (c == '.')


### PR DESCRIPTION
As discussed in #1773, it's probably a good idea to show a warning about usage of slashes in `require`, then evalue when to enforce this by throwing Lua error.