### PR TITLE
Windows: Fix compile error loses precision

### DIFF
--- a/src/modules/system/System.cpp
+++ b/src/modules/system/System.cpp
@@ -164,7 +164,7 @@ bool System::openURL(const std::string &url) const
 
 #endif
 
-	return (int) result > 32;
+	return (ptrdiff_t) result > 32;
 
 #endif
 }


### PR DESCRIPTION
see [1786](https://github.com/love2d/love/issues/1786)
error: cast from 'HINSTANCE' {aka 'HINSTANCE__*'} to 'int' loses precision [-fpermissive]