### PR TITLE
Support for Audio Device Selection and Disconnection Callback

### DIFF
--- a/src/modules/audio/Audio.cpp
+++ b/src/modules/audio/Audio.cpp
@@ -78,7 +78,7 @@ bool Audio::setMixWithSystem(bool mix)
 #endif
 }
 
-void Audio::setOutputDevice(const char */*name*/)
+void Audio::setPlaybackDevice(const char */*name*/)
 {
 	throw love::Exception("Re-setting output device is not supported.");
 }

--- a/src/modules/audio/Audio.cpp
+++ b/src/modules/audio/Audio.cpp
@@ -78,6 +78,11 @@ bool Audio::setMixWithSystem(bool mix)
 #endif
 }
 
+void Audio::setOutputDevice(const char */*name*/)
+{
+	throw love::Exception("Re-setting output device is not supported.");
+}
+
 StringMap<Audio::DistanceModel, Audio::DISTANCE_MAX_ENUM>::Entry Audio::distanceModelEntries[] =
 {
 	{"none", Audio::DISTANCE_NONE},

--- a/src/modules/audio/Audio.h
+++ b/src/modules/audio/Audio.h
@@ -298,19 +298,19 @@ public:
 	virtual void resumeContext() = 0;
 
 	/**
-	 * Get current output device name.
+	 * Get current playback device name.
 	 */
-	virtual std::string getOutputDevice() = 0;
+	virtual std::string getPlaybackDevice() = 0;
 
 	/**
-	 * Retrieve list of available output devices.
+	 * Retrieve list of available playback devices.
 	 */
-	virtual void getOutputDevices(std::vector<std::string> &list) = 0;
+	virtual void getPlaybackDevices(std::vector<std::string> &list) = 0;
 
 	/**
-	 * Set the output device to specified device name.
+	 * Set the current playback device to specified device name.
 	 */
-	virtual void setOutputDevice(const char *name);
+	virtual void setPlaybackDevice(const char *name);
 
 private:
 

--- a/src/modules/audio/Audio.h
+++ b/src/modules/audio/Audio.h
@@ -307,6 +307,11 @@ public:
 	 */
 	virtual void getOutputDevices(std::vector<std::string> &list) = 0;
 
+	/**
+	 * Set the output device to specified device name.
+	 */
+	virtual void setOutputDevice(const char *name);
+
 private:
 
 	static StringMap<DistanceModel, DISTANCE_MAX_ENUM>::Entry distanceModelEntries[];

--- a/src/modules/audio/Audio.h
+++ b/src/modules/audio/Audio.h
@@ -297,6 +297,16 @@ public:
 	virtual void pauseContext() = 0;
 	virtual void resumeContext() = 0;
 
+	/**
+	 * Get current output device name.
+	 */
+	virtual std::string getOutputDevice() = 0;
+
+	/**
+	 * Retrieve list of available output devices.
+	 */
+	virtual void getOutputDevices(std::vector<std::string> &list) = 0;
+
 private:
 
 	static StringMap<DistanceModel, DISTANCE_MAX_ENUM>::Entry distanceModelEntries[];

--- a/src/modules/audio/null/Audio.cpp
+++ b/src/modules/audio/null/Audio.cpp
@@ -211,12 +211,12 @@ void Audio::resumeContext()
 {
 }
 
-std::string Audio::getOutputDevice()
+std::string Audio::getPlaybackDevice()
 {
 	return "";
 }
 
-void Audio::getOutputDevices(std::vector<std::string> &/*list*/)
+void Audio::getPlaybackDevices(std::vector<std::string> &/*list*/)
 {
 }
 

--- a/src/modules/audio/null/Audio.cpp
+++ b/src/modules/audio/null/Audio.cpp
@@ -211,6 +211,15 @@ void Audio::resumeContext()
 {
 }
 
+std::string Audio::getOutputDevice()
+{
+	return "";
+}
+
+void Audio::getOutputDevices(std::vector<std::string> &/*list*/)
+{
+}
+
 
 } // null
 } // audio

--- a/src/modules/audio/null/Audio.h
+++ b/src/modules/audio/null/Audio.h
@@ -89,6 +89,9 @@ public:
 	void pauseContext();
 	void resumeContext();
 
+	std::string getOutputDevice();
+	void getOutputDevices(std::vector<std::string> &list);
+
 private:
 	float volume;
 	DistanceModel distanceModel;

--- a/src/modules/audio/null/Audio.h
+++ b/src/modules/audio/null/Audio.h
@@ -89,8 +89,8 @@ public:
 	void pauseContext();
 	void resumeContext();
 
-	std::string getOutputDevice();
-	void getOutputDevices(std::vector<std::string> &list);
+	std::string getPlaybackDevice();
+	void getPlaybackDevices(std::vector<std::string> &list);
 
 private:
 	float volume;

--- a/src/modules/audio/openal/Audio.cpp
+++ b/src/modules/audio/openal/Audio.cpp
@@ -328,7 +328,7 @@ void Audio::resumeContext()
 		alcMakeContextCurrent(context);
 }
 
-std::string Audio::getOutputDevice()
+std::string Audio::getPlaybackDevice()
 {
 	const char *dev = getDeviceSpecifier(device);
 
@@ -338,7 +338,7 @@ std::string Audio::getOutputDevice()
 	return dev;
 }
 
-void Audio::getOutputDevices(std::vector<std::string> &list)
+void Audio::getPlaybackDevices(std::vector<std::string> &list)
 {
 	const char *devices = getDeviceSpecifier(nullptr);
 
@@ -352,7 +352,7 @@ void Audio::getOutputDevices(std::vector<std::string> &list)
 	}
 }
 
-void Audio::setOutputDevice(const char* name)
+void Audio::setPlaybackDevice(const char* name)
 {
 #ifndef ALC_SOFT_reopen_device
 	typedef ALCboolean (ALC_APIENTRY*LPALCREOPENDEVICESOFT)(ALCdevice *device,
@@ -366,7 +366,7 @@ void Audio::setOutputDevice(const char* name)
 	{
 		// Default implementation throws exception. To make
 		// error message consistent, call the base class.
-		love::audio::Audio::setOutputDevice(name);
+		love::audio::Audio::setPlaybackDevice(name);
 		return;
 	}
 

--- a/src/modules/audio/openal/Audio.cpp
+++ b/src/modules/audio/openal/Audio.cpp
@@ -179,7 +179,7 @@ Audio::Audio()
 
 	try
 	{
-		pool = new Pool();
+		pool = new Pool(device);
 	}
 	catch (love::Exception &)
 	{
@@ -354,7 +354,6 @@ void Audio::getOutputDevices(std::vector<std::string> &list)
 
 void Audio::setOutputDevice(const char* name)
 {
-#undef ALC_SOFT_reopen_device
 #ifndef ALC_SOFT_reopen_device
 	typedef ALCboolean (ALC_APIENTRY*LPALCREOPENDEVICESOFT)(ALCdevice *device,
 		const ALCchar *deviceName, const ALCint *attribs);

--- a/src/modules/audio/openal/Audio.h
+++ b/src/modules/audio/openal/Audio.h
@@ -129,6 +129,7 @@ public:
 
 	std::string getOutputDevice();
 	void getOutputDevices(std::vector<std::string> &list);
+	void setOutputDevice(const char *name);
 
 private:
 	void initializeEFX();
@@ -140,6 +141,7 @@ private:
 
 	// The OpenAL context.
 	ALCcontext *context;
+	std::vector<ALCint> attribs;
 
 	// The OpenAL effects
 	struct EffectMapStorage

--- a/src/modules/audio/openal/Audio.h
+++ b/src/modules/audio/openal/Audio.h
@@ -127,6 +127,9 @@ public:
 
 	bool getEffectID(const char *name, ALuint &id);
 
+	std::string getOutputDevice();
+	void getOutputDevices(std::vector<std::string> &list);
+
 private:
 	void initializeEFX();
 	// The OpenAL device.

--- a/src/modules/audio/openal/Audio.h
+++ b/src/modules/audio/openal/Audio.h
@@ -127,9 +127,9 @@ public:
 
 	bool getEffectID(const char *name, ALuint &id);
 
-	std::string getOutputDevice();
-	void getOutputDevices(std::vector<std::string> &list);
-	void setOutputDevice(const char *name);
+	std::string getPlaybackDevice();
+	void getPlaybackDevices(std::vector<std::string> &list);
+	void setPlaybackDevice(const char *name);
 
 private:
 	void initializeEFX();

--- a/src/modules/audio/openal/Pool.h
+++ b/src/modules/audio/openal/Pool.h
@@ -64,7 +64,7 @@ class Pool
 {
 public:
 
-	Pool();
+	Pool(ALCdevice *device);
 	~Pool();
 
 	/**
@@ -101,8 +101,14 @@ private:
 	// Maximum possible number of OpenAL sources the pool attempts to generate.
 	static const int MAX_SOURCES = 64;
 
+	// Current OpenAL device
+	ALCdevice *device;
+
 	// OpenAL sources
 	ALuint sources[MAX_SOURCES];
+
+	// Is device disconnection has been notified?
+	bool disconnectNotified;
 
 	// Total number of created sources in the pool.
 	int totalSources;

--- a/src/modules/audio/wrap_Audio.cpp
+++ b/src/modules/audio/wrap_Audio.cpp
@@ -543,6 +543,31 @@ int w_setMixWithSystem(lua_State *L)
 	return 1;
 }
 
+int w_getOutputDevice(lua_State* L)
+{
+	std::string device;
+
+	luax_catchexcept(L, [&]() { device = instance()->getOutputDevice(); });
+	luax_pushstring(L, device);
+	return 1;
+}
+
+int w_getOutputDevices(lua_State* L)
+{
+	std::vector<std::string> list;
+
+	luax_catchexcept(L, [&]() { instance()->getOutputDevices(list); });
+	lua_createtable(L, 0, (int) list.size());
+	for (int i = 0; i < (int) list.size(); i++)
+	{
+		lua_pushnumber(L, i + 1);
+		lua_pushstring(L, list[i].c_str());
+		lua_rawset(L, -3);
+	}
+
+	return 1;
+}
+
 // List of functions to wrap.
 static const luaL_Reg functions[] =
 {
@@ -574,6 +599,8 @@ static const luaL_Reg functions[] =
 	{ "getMaxSourceEffects", w_getMaxSourceEffects },
 	{ "isEffectsSupported", w_isEffectsSupported },
 	{ "setMixWithSystem", w_setMixWithSystem },
+	{ "getOutputDevice", w_getOutputDevice },
+	{ "getOutputDevices", w_getOutputDevices },
 
 	{ 0, 0 }
 };

--- a/src/modules/audio/wrap_Audio.cpp
+++ b/src/modules/audio/wrap_Audio.cpp
@@ -568,6 +568,27 @@ int w_getOutputDevices(lua_State* L)
 	return 1;
 }
 
+int w_setOutputDevice(lua_State* L)
+{
+	const char *device = luaL_optstring(L, 1, nullptr);
+
+	try
+	{
+		instance()->setOutputDevice(device);
+		luax_pushboolean(L, true);
+		return 1;
+	}
+	catch (love::Exception& e)
+	{
+		luax_pushboolean(L, false);
+		lua_pushstring(L, e.what());
+		return 2;
+	}
+
+	// To avoid compiler warning
+	return 0;
+}
+
 // List of functions to wrap.
 static const luaL_Reg functions[] =
 {
@@ -601,6 +622,7 @@ static const luaL_Reg functions[] =
 	{ "setMixWithSystem", w_setMixWithSystem },
 	{ "getOutputDevice", w_getOutputDevice },
 	{ "getOutputDevices", w_getOutputDevices },
+	{ "setOutputDevice", w_setOutputDevice },
 
 	{ 0, 0 }
 };

--- a/src/modules/audio/wrap_Audio.cpp
+++ b/src/modules/audio/wrap_Audio.cpp
@@ -543,20 +543,20 @@ int w_setMixWithSystem(lua_State *L)
 	return 1;
 }
 
-int w_getOutputDevice(lua_State* L)
+int w_getPlaybackDevice(lua_State* L)
 {
 	std::string device;
 
-	luax_catchexcept(L, [&]() { device = instance()->getOutputDevice(); });
+	luax_catchexcept(L, [&]() { device = instance()->getPlaybackDevice(); });
 	luax_pushstring(L, device);
 	return 1;
 }
 
-int w_getOutputDevices(lua_State* L)
+int w_getPlaybackDevices(lua_State* L)
 {
 	std::vector<std::string> list;
 
-	luax_catchexcept(L, [&]() { instance()->getOutputDevices(list); });
+	luax_catchexcept(L, [&]() { instance()->getPlaybackDevices(list); });
 	lua_createtable(L, 0, (int) list.size());
 	for (int i = 0; i < (int) list.size(); i++)
 	{
@@ -568,13 +568,13 @@ int w_getOutputDevices(lua_State* L)
 	return 1;
 }
 
-int w_setOutputDevice(lua_State* L)
+int w_setPlaybackDevice(lua_State* L)
 {
 	const char *device = luaL_optstring(L, 1, nullptr);
 
 	try
 	{
-		instance()->setOutputDevice(device);
+		instance()->setPlaybackDevice(device);
 		luax_pushboolean(L, true);
 		return 1;
 	}
@@ -620,9 +620,9 @@ static const luaL_Reg functions[] =
 	{ "getMaxSourceEffects", w_getMaxSourceEffects },
 	{ "isEffectsSupported", w_isEffectsSupported },
 	{ "setMixWithSystem", w_setMixWithSystem },
-	{ "getOutputDevice", w_getOutputDevice },
-	{ "getOutputDevices", w_getOutputDevices },
-	{ "setOutputDevice", w_setOutputDevice },
+	{ "getPlaybackDevice", w_getPlaybackDevice },
+	{ "getPlaybackDevices", w_getPlaybackDevices },
+	{ "setPlaybackDevice", w_setPlaybackDevice },
 
 	{ 0, 0 }
 };

--- a/src/modules/love/callbacks.lua
+++ b/src/modules/love/callbacks.lua
@@ -129,6 +129,11 @@ function love.createhandlers()
 		localechanged = function ()
 			if love.localechanged then return love.localechanged() end
 		end,
+		audiodisconnected = function ()
+			if not love.audiodisconnected or not love.audiodisconnected() then
+				love.audio.setOutputDevice()
+			end
+		end,
 	}, {
 		__index = function(self, name)
 			error("Unknown event: " .. name)

--- a/src/modules/love/callbacks.lua
+++ b/src/modules/love/callbacks.lua
@@ -131,7 +131,7 @@ function love.createhandlers()
 		end,
 		audiodisconnected = function (sources)
 			if not love.audiodisconnected or not love.audiodisconnected(sources) then
-				love.audio.setOutputDevice()
+				love.audio.setPlaybackDevice()
 			end
 		end,
 	}, {

--- a/src/modules/love/callbacks.lua
+++ b/src/modules/love/callbacks.lua
@@ -129,8 +129,8 @@ function love.createhandlers()
 		localechanged = function ()
 			if love.localechanged then return love.localechanged() end
 		end,
-		audiodisconnected = function ()
-			if not love.audiodisconnected or not love.audiodisconnected() then
+		audiodisconnected = function (sources)
+			if not love.audiodisconnected or not love.audiodisconnected(sources) then
 				love.audio.setOutputDevice()
 			end
 		end,


### PR DESCRIPTION
A simpler approach to #1804. Fixes #1537 _completely_.

This pull request adds several features:
* `love.audio.getPlaybackDevice()` function get current playback device name.
* `love.audio.getPlaybackDevices()` function retrieves all available playback devices in a Lua table.
* `love.audio.setPlaybackDevice(name)` function re-set the output device to `name`. `name` can be `nil` (for automatic default) or a string returned from `love.audio.getPlaybackDevices()` function above. Returns `true` on success or `false` and error message on failure.
* `love.audiodisconnected` callback when the audio device is disconnected and must be reconnected with `love.audio.setPlaybackDevice()`.

Now here are some notes:
* `love.audio.setPlaybackDevice()` is only supported if [ALC_SOFT_reopen_device](https://openal-soft.org/openal-extensions/SOFT_reopen_device.txt) extension is supported. Since you can't set to alternative device without this function, `love.audio.getPlaybackDevices()` is not really useful in that case. It could be possible to allow complete audio reinitialization with `love.audio.setPlaybackDevice()` before any other calls to `love.audio` is made to support scenario where "ALC_SOFT_reopen_device" extension is not supported but this adds slight complexity to the `Audio` class.
* `love.audiodisconnected` callback support depends on [ALC_EXT_disconnect](http://icculus.org/alextreg/wiki/action=printer&id=ALC_EXT_Disconnect) extension and is backend-dependent. It may or may not fire the callback when the audio is disconnected.
* When `love.audiodisconnected` callback is called, all previously playing sources are paused, then stopped a second later (`Source:tell()` returns 0). The latter may OpenAL-soft specific behavior though.
* Re-setting output device clears all the OpenAL internal buffer. ~~For "stream" sources, this desynchronize `Source:tell()` between the actual played audio, either slightly or significantly. For "static" sources, the source is stopped completely and must be re-played from the beginning.~~ I decided to stop all sources instead.