### PR TITLE
Added World:getFixturesInArea()

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -45,6 +45,7 @@ Released: N/A
 * Added love.keyboard.isModifierActive.
 * Added love.system.getPreferredLocales.
 * Added love.localechanged callback.
+* Added World:getFixturesInArea().
 
 * Changed the default font from Vera size 12 to Noto Sans size 13.
 * Changed the Texture class and implementation to no longer have separate Canvas and Image subclasses.
@@ -165,7 +166,7 @@ Released: 2019-10-27
 * Fixed audio clicks immediately after playing a Source on iOS.
 * Fixed Source:play + Source:stop + Source:play looping the first few ms of sound for streaming Sources on iOS.
 * Fixed Source:play + Source:seek looping the first few ms of sound for streaming Sources on iOS.
-* Fixed occasional pops in streaming sources on iOS. 
+* Fixed occasional pops in streaming sources on iOS.
 * Fixed love.audio.play(sources) to use previously set playback positions on stopped Sources.
 * Fixed Source:setEffect(name, true) and Source:getEffect(name) when the effect has no associated Filter.
 * Fixed love.audio.newSource(filename, "queue") to cause a Lua error.
@@ -437,7 +438,7 @@ Released: 2016-10-31
 
   * Improved performance of Channel methods by roughly 2x in many cases.
   * Improved performance of Shader:send when small numbers of arguments are given.
-  
+
   * Updated love.filesystem.mount to accept a DroppedFile as the first parameter.
   * Updated Shader:send to do type and argument checking based on the specified uniform variable's information instead of the arguments to the function.
   * Updated Shader:send to accept a flat table for matrix uniforms.

--- a/src/modules/physics/box2d/World.cpp
+++ b/src/modules/physics/box2d/World.cpp
@@ -171,6 +171,28 @@ bool World::QueryCallback::ReportFixture(b2Fixture *fixture)
 	return true;
 }
 
+World::CollectCallback::CollectCallback(World *world, lua_State *L)
+  : world(world)
+  , L(L)
+{
+  lua_newtable(L);
+}
+
+World::CollectCallback::~CollectCallback()
+{
+}
+
+bool World::CollectCallback::ReportFixture(b2Fixture *f)
+{
+  Fixture* fixture = (Fixture*)world->findObject(f);
+  if (!fixture)
+    throw love::Exception("A fixture has escaped Memoizer!");
+  luax_pushtype(L, fixture);
+  lua_rawseti(L, -2, i);
+  i++;
+  return true;
+}
+
 World::RayCastCallback::RayCastCallback(World *world, lua_State *L, int idx)
 	: world(world)
 	, L(L)
@@ -554,6 +576,20 @@ int World::queryBoundingBox(lua_State *L)
 	QueryCallback query(this, L, 5);
 	world->QueryAABB(&query, box);
 	return 0;
+}
+
+int World::getFixturesInArea(lua_State *L)
+{
+  float lx = (float)luaL_checknumber(L, 1);
+  float ly = (float)luaL_checknumber(L, 2);
+  float ux = (float)luaL_checknumber(L, 3);
+  float uy = (float)luaL_checknumber(L, 4);
+	b2AABB box;
+  box.lowerBound = Physics::scaleDown(b2Vec2(lx, ly));
+  box.upperBound = Physics::scaleDown(b2Vec2(ux, uy));
+  CollectCallback query(this, L);
+  world->QueryAABB(&query, box);
+  return 1;
 }
 
 int World::rayCast(lua_State *L)

--- a/src/modules/physics/box2d/World.cpp
+++ b/src/modules/physics/box2d/World.cpp
@@ -172,10 +172,10 @@ bool World::QueryCallback::ReportFixture(b2Fixture *fixture)
 }
 
 World::CollectCallback::CollectCallback(World *world, lua_State *L)
-  : world(world)
-  , L(L)
+	: world(world)
+	, L(L)
 {
-  lua_newtable(L);
+	lua_newtable(L);
 }
 
 World::CollectCallback::~CollectCallback()
@@ -184,13 +184,13 @@ World::CollectCallback::~CollectCallback()
 
 bool World::CollectCallback::ReportFixture(b2Fixture *f)
 {
-  Fixture* fixture = (Fixture*)world->findObject(f);
-  if (!fixture)
-    throw love::Exception("A fixture has escaped Memoizer!");
-  luax_pushtype(L, fixture);
-  lua_rawseti(L, -2, i);
-  i++;
-  return true;
+	Fixture *fixture = (Fixture *)world->findObject(f);
+	if (!fixture)
+		throw love::Exception("A fixture has escaped Memoizer!");
+	luax_pushtype(L, fixture);
+	lua_rawseti(L, -2, i);
+	i++;
+	return true;
 }
 
 World::RayCastCallback::RayCastCallback(World *world, lua_State *L, int idx)
@@ -580,16 +580,16 @@ int World::queryBoundingBox(lua_State *L)
 
 int World::getFixturesInArea(lua_State *L)
 {
-  float lx = (float)luaL_checknumber(L, 1);
-  float ly = (float)luaL_checknumber(L, 2);
-  float ux = (float)luaL_checknumber(L, 3);
-  float uy = (float)luaL_checknumber(L, 4);
+	float lx = (float)luaL_checknumber(L, 1);
+	float ly = (float)luaL_checknumber(L, 2);
+	float ux = (float)luaL_checknumber(L, 3);
+	float uy = (float)luaL_checknumber(L, 4);
 	b2AABB box;
-  box.lowerBound = Physics::scaleDown(b2Vec2(lx, ly));
-  box.upperBound = Physics::scaleDown(b2Vec2(ux, uy));
-  CollectCallback query(this, L);
-  world->QueryAABB(&query, box);
-  return 1;
+	box.lowerBound = Physics::scaleDown(b2Vec2(lx, ly));
+	box.upperBound = Physics::scaleDown(b2Vec2(ux, uy));
+	CollectCallback query(this, L);
+	world->QueryAABB(&query, box);
+	return 1;
 }
 
 int World::rayCast(lua_State *L)

--- a/src/modules/physics/box2d/World.h
+++ b/src/modules/physics/box2d/World.h
@@ -102,6 +102,18 @@ public:
 		int funcidx;
 	};
 
+  class CollectCallback : public b2QueryCallback
+  {
+  public:
+    CollectCallback(World *world, lua_State *L);
+    ~CollectCallback();
+    virtual bool ReportFixture(b2Fixture *fixture);
+  private:
+    World *world;
+		lua_State *L;
+    int i = 1;
+  };
+
 	class RayCastCallback : public b2RayCastCallback
 	{
 	public:
@@ -270,9 +282,15 @@ public:
 	b2Body *getGroundBody() const;
 
 	/**
-	 * Gets all fixtures that overlap a given bounding box.
+	 * Calls a callback on all fixtures that overlap a given bounding box.
 	 **/
 	int queryBoundingBox(lua_State *L);
+
+	/**
+	 * Gets all fixtures that overlap a given bounding box.
+	 **/
+	int getFixturesInArea(lua_State *L);
+
 
 	/**
 	 * Raycasts the World for all Fixtures in the path of the ray.

--- a/src/modules/physics/box2d/World.h
+++ b/src/modules/physics/box2d/World.h
@@ -102,17 +102,17 @@ public:
 		int funcidx;
 	};
 
-  class CollectCallback : public b2QueryCallback
-  {
-  public:
-    CollectCallback(World *world, lua_State *L);
-    ~CollectCallback();
-    virtual bool ReportFixture(b2Fixture *fixture);
-  private:
-    World *world;
+	class CollectCallback : public b2QueryCallback
+	{
+	public:
+		CollectCallback(World *world, lua_State *L);
+		~CollectCallback();
+		virtual bool ReportFixture(b2Fixture *fixture);
+	private:
+		World *world;
 		lua_State *L;
-    int i = 1;
-  };
+		int i = 1;
+	};
 
 	class RayCastCallback : public b2RayCastCallback
 	{

--- a/src/modules/physics/box2d/World.h
+++ b/src/modules/physics/box2d/World.h
@@ -291,7 +291,6 @@ public:
 	 **/
 	int getFixturesInArea(lua_State *L);
 
-
 	/**
 	 * Raycasts the World for all Fixtures in the path of the ray.
 	 **/

--- a/src/modules/physics/box2d/wrap_World.cpp
+++ b/src/modules/physics/box2d/wrap_World.cpp
@@ -185,6 +185,15 @@ int w_World_queryBoundingBox(lua_State *L)
 	return t->queryBoundingBox(L);
 }
 
+int w_World_getFixturesInArea(lua_State *L)
+{
+	World *t = luax_checkworld(L, 1);
+  lua_remove(L, 1);
+  int ret = 0;
+  luax_catchexcept(L, [&](){ ret = t->getFixturesInArea(L); });
+	return ret;
+}
+
 int w_World_rayCast(lua_State *L)
 {
 	World *t = luax_checkworld(L, 1);
@@ -228,6 +237,7 @@ static const luaL_Reg w_World_functions[] =
 	{ "getJoints", w_World_getJoints },
 	{ "getContacts", w_World_getContacts },
 	{ "queryBoundingBox", w_World_queryBoundingBox },
+	{ "getFixturesInArea", w_World_getFixturesInArea },
 	{ "rayCast", w_World_rayCast },
 	{ "destroy", w_World_destroy },
 	{ "isDestroyed", w_World_isDestroyed },

--- a/src/modules/physics/box2d/wrap_World.cpp
+++ b/src/modules/physics/box2d/wrap_World.cpp
@@ -188,9 +188,9 @@ int w_World_queryBoundingBox(lua_State *L)
 int w_World_getFixturesInArea(lua_State *L)
 {
 	World *t = luax_checkworld(L, 1);
-  lua_remove(L, 1);
-  int ret = 0;
-  luax_catchexcept(L, [&](){ ret = t->getFixturesInArea(L); });
+	lua_remove(L, 1);
+	int ret = 0;
+	luax_catchexcept(L, [&](){ ret = t->getFixturesInArea(L); });
 	return ret;
 }
 


### PR DESCRIPTION
[Quality of life]

I find writing the callback to get all the fixtures in an area a hassle, I just want a list of them.
This is a quality of life more than anything else, instead of this:
```lua
      local fixtures = {}
      local callback = function(fixture)
        table.insert(fixtures, fixture)
        return true
      end
      world:queryBoundingBox(-500, -500, 500, 500, callback)
      print(#fixtures)
```
      
You can do just 
```lua
      local fixtures = world:getFixturesInArea(-500, -500, 500, 500)
      print(#fixtures)
```

Because there is less indirection, it has a modest performance improvement compared to the callback method:
Measured in debug build, total time 10,000 calls, on an area with 100 fixtures:
![love_Fegs3z0Izw](https://user-images.githubusercontent.com/11986037/187036658-2d75be81-4426-413c-926c-836fd60e52f6.png)

And the same test in Release build:
![image](https://user-images.githubusercontent.com/11986037/187036817-959c6d21-dc23-4bb7-93cf-33c39a3dbe53.png)

So its maybe 1.35x faster or so.
      
      