### PR TITLE
FIx polyline adding NaN normals, which breaks the line rendering

### DIFF
--- a/src/modules/graphics/Polyline.cpp
+++ b/src/modules/graphics/Polyline.cpp
@@ -24,6 +24,7 @@
 
 // C++
 #include <algorithm>
+#include <assert.h>
 
 // treat adjacent segments with angles between their directions <5 degree as straight
 static const float LINES_PARALLEL_EPS = 0.05f;
@@ -176,6 +177,12 @@ void MiterJoinPolyline::renderEdge(std::vector<Vector2> &anchors, std::vector<Ve
 {
 	Vector2 t    = (r - q);
 	float len_t = t.getLength();
+	if (len_t == 0.0f)
+	{
+		// degenerate segment, skip it
+		return;
+	}
+
 	Vector2 nt   = t.getNormal(hw / len_t);
 
 	anchors.push_back(q);
@@ -185,6 +192,7 @@ void MiterJoinPolyline::renderEdge(std::vector<Vector2> &anchors, std::vector<Ve
 	if (fabs(det) / (len_s * len_t) < LINES_PARALLEL_EPS && Vector2::dot(s, t) > 0)
 	{
 		// lines parallel, compute as u1 = q + ns * w/2, u2 = q - ns * w/2
+		assert(ns == ns); //NaN check
 		normals.push_back(ns);
 		normals.push_back(-ns);
 	}
@@ -193,6 +201,7 @@ void MiterJoinPolyline::renderEdge(std::vector<Vector2> &anchors, std::vector<Ve
 		// cramers rule
 		float lambda = Vector2::cross((nt - ns), t) / det;
 		Vector2 d = ns + s * lambda;
+		assert(d == d); //NaN check
 		normals.push_back(d);
 		normals.push_back(-d);
 	}


### PR DESCRIPTION
Resolves https://github.com/love2d/love/issues/1760

The drawing was having these NAN normals inserted, because the segment length was 0.
This adds asserts to check the normals are never NAN, and early return to skip the line segment if the length is 0.

-------------------------------------------

Before, using this in Love2d:
```lua
love.graphics.line(0, 0, 50, 50, 50, 50, 100, 100)
```

Results in the line draw normals looking like this:

![Code_I2fkkV4mG9](https://user-images.githubusercontent.com/11986037/190602488-5188b59c-79e9-4315-aaf7-82b97f380fd8.png)

Which through some mechanism, doesn't crash, but doesn't draw the line either (points drawn for debug):

![image](https://user-images.githubusercontent.com/11986037/190602727-c6aee321-38b9-4ec5-9ee0-a8be4202fdd4.png)

With the skipping of length 0 segments, the normals will look valid, and the line will draw as expected:

![Code_nWykJnNO3R](https://user-images.githubusercontent.com/11986037/190603544-c9fddf17-2c86-4066-a7c1-faa5db0972ca.png)

![image](https://user-images.githubusercontent.com/11986037/190602972-eedef795-0c65-4ed9-bd17-b391bbf032f0.png)

-----------------------------------

Duplicate points don't seem to cause any problem with the "none" and "bevel" join styles, so I didn't worry about skipping the points for those cases (though it would probably be fine and save some wasted time)

