### PR TITLE
Add optional load mode parameter to love.filesystem.load.

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -9,6 +9,7 @@ Released: N/A
 * Added love.filesystem.mountFullPath and love.filesystem.unmountFullPath, including opt-in mount-for-write support.
 * Added love.filesystem.mountCommonPath, unmountCommonPath, and getFullCommonPath.
 * Added 'readonly' field to love.filesystem.getInfo's returned table.
+* Added an optional load mode parameter to love.filesystem.load whetever to only allow binary chunks, text chunks, or both.
 * Added SoundData:copyFrom.
 * Added SoundData:slice.
 * Added Joystick:setPlayerIndex and Joystick:getPlayerIndex.

--- a/src/modules/filesystem/Filesystem.cpp
+++ b/src/modules/filesystem/Filesystem.cpp
@@ -221,5 +221,13 @@ STRINGMAP_CLASS_BEGIN(Filesystem, Filesystem::MountPermissions, Filesystem::MOUN
 }
 STRINGMAP_CLASS_END(Filesystem, Filesystem::MountPermissions, Filesystem::MOUNT_PERMISSIONS_MAX_ENUM, mountPermissions)
 
+STRINGMAP_CLASS_BEGIN(Filesystem, Filesystem::LoadMode, Filesystem::LOADMODE_MAX_ENUM, loadMode)
+{
+	{ "b",  Filesystem::LOADMODE_BINARY},
+	{ "t",  Filesystem::LOADMODE_TEXT  },
+	{ "bt", Filesystem::LOADMODE_ANY   }
+}
+STRINGMAP_CLASS_END(Filesystem, Filesystem::LoadMode, Filesystem::LOADMODE_MAX_ENUM, loadMode)
+
 } // filesystem
 } // love

--- a/src/modules/filesystem/Filesystem.h
+++ b/src/modules/filesystem/Filesystem.h
@@ -89,6 +89,14 @@ public:
 		MOUNT_PERMISSIONS_MAX_ENUM
 	};
 
+	enum LoadMode
+	{
+		LOADMODE_BINARY,
+		LOADMODE_TEXT,
+		LOADMODE_ANY,
+		LOADMODE_MAX_ENUM
+	};
+
 	struct Info
 	{
 		// Numbers will be -1 if they cannot be determined.
@@ -307,6 +315,7 @@ public:
 	STRINGMAP_CLASS_DECLARE(FileType);
 	STRINGMAP_CLASS_DECLARE(CommonPath);
 	STRINGMAP_CLASS_DECLARE(MountPermissions);
+	STRINGMAP_CLASS_DECLARE(LoadMode);
 
 private:
 


### PR DESCRIPTION
This adds optional `loadMode` parameter to `love.filesystem.load(path, loadMode)`. `loadMode` can be `"b"` to only accept binary chunk, `"t"` to only accept text chunk, or `"bt"` for both. `"bt"` is the default behavior if not specified. Fixes #1849

Note that this effectively prevents people who trying to switch between Lua 5.1 and LuaJIT in Windows by replacing the DLL. If this is undesired please let me know so I can think of another approach.