### PR TITLE
Add Data:getIntArray

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -48,6 +48,7 @@ Released: N/A
 * Added love.system.getPreferredLocales.
 * Added love.localechanged callback.
 * Added World:getFixturesInArea().
+* Added Data:getIntArray().
 
 * Changed the default font from Vera size 12 to Noto Sans size 13.
 * Changed the Texture class and implementation to no longer have separate Canvas and Image subclasses.

--- a/src/modules/data/wrap_Data.cpp
+++ b/src/modules/data/wrap_Data.cpp
@@ -42,6 +42,68 @@ int w_Data_getString(lua_State *L)
 	return 1;
 }
 
+template <class Int> void getIntArray(lua_State *L, size_t size, void *data)
+{
+	Int *idata = (Int *) data;
+	size_t length = size / sizeof(Int);
+	lua_createtable(L, (int)length, 0);
+	for (size_t i = 1; i <= length; ++i)
+	{
+		lua_pushinteger(L, i);
+		lua_pushinteger(L, (lua_Integer) *idata);
+		lua_settable(L, -3);
+		++idata;
+	}
+}
+
+int w_Data_getIntArray(lua_State *L)
+{
+	Data *t = luax_checkdata(L, 1);
+	const char *issigned = luaL_optstring(L, 2, "s");
+	int width = luaL_optint(L, 3, 4);
+
+	if (*issigned == 'u')
+	{
+		switch (width) {
+		case 1:
+			getIntArray<uint8_t>(L, t->getSize(), t->getData());
+			break;
+		case 2:
+			getIntArray<uint16_t>(L, t->getSize(), t->getData());
+			break;
+		case 4:
+			getIntArray<uint32_t>(L, t->getSize(), t->getData());
+			break;
+		case 8:
+			getIntArray<uint64_t>(L, t->getSize(), t->getData());
+			break;
+		default:
+			lua_pushnil(L);
+		}
+	}
+	else
+	{
+		switch (width)
+		{
+		case 1:
+			getIntArray<int8_t>(L, t->getSize(), t->getData());
+			break;
+		case 2:
+			getIntArray<int16_t>(L, t->getSize(), t->getData());
+			break;
+		case 4:
+			getIntArray<int32_t>(L, t->getSize(), t->getData());
+			break;
+		case 8:
+			getIntArray<int64_t>(L, t->getSize(), t->getData());
+			break;
+		default:
+			lua_pushnil(L);
+		}
+	}
+	return 1;
+}
+
 int w_Data_getPointer(lua_State *L)
 {
 	Data *t = luax_checkdata(L, 1);
@@ -81,6 +143,7 @@ static FFI_Data ffifuncs =
 const luaL_Reg w_Data_functions[] =
 {
 	{ "getString", w_Data_getString },
+	{ "getIntArray", w_Data_getIntArray },
 	{ "getPointer", w_Data_getPointer },
 	{ "getFFIPointer", w_Data_getFFIPointer },
 	{ "getSize", w_Data_getSize },

--- a/src/modules/data/wrap_Data.cpp
+++ b/src/modules/data/wrap_Data.cpp
@@ -78,7 +78,7 @@ int w_Data_getIntArray(lua_State *L)
 			getIntArray<uint64_t>(L, t->getSize(), t->getData());
 			break;
 		default:
-			lua_pushnil(L);
+			throw love::Exception("Invalid integer size. Must be 1, 2, 4, or 8.");
 		}
 	}
 	else
@@ -98,7 +98,7 @@ int w_Data_getIntArray(lua_State *L)
 			getIntArray<int64_t>(L, t->getSize(), t->getData());
 			break;
 		default:
-			lua_pushnil(L);
+			throw love::Exception("Invalid integer size. Must be 1, 2, 4, or 8.");
 		}
 	}
 	return 1;


### PR DESCRIPTION
# Data:getIntArray

A convenient shortcut for the common case of reading data as an int array.

```lua
--Before
    local array = {}
    local i, n = 1, data:getSize()
    while i <= n do
        array[#array + 1], i = love.data.unpack("<I4", data, i)
    end

--After
    array = data:getIntArray('u', 4, 'l')
```

## Arguments

- string `signedness`
  - 'u' for unsigned. Anything else for signed. Default is signed.
- number `intsize`
  - How many bytes in each int. Supports 1, 2, 4, or 8. Default is 4. Any other value causes an error.
- string `endianness`
  - Which byte order the ints are stored in. 'l' for little endian, 'b' for big endian. Default is the running machine's endianness.

## Returns

- table `intarray`
  - Table of the numbers read from the data.