### PR TITLE
print usage when there is no game and when --help option is used

### DIFF
--- a/src/love.cpp
+++ b/src/love.cpp
@@ -141,6 +141,21 @@ enum DoneAction
 	DONE_RESTART,
 };
 
+static void print_usage()
+{
+    // when editing this message, change it at boot.lua too
+    printf("LÖVE is an *awesome* framework you can use to make 2D games in Lua\n"
+        "https://love2d.org\n"
+        "\n"
+        "usage:\n"
+        "    love --version                  prints LÖVE version and quits\n"
+        "    love --help                     prints this message and quits\n"
+        "    love path/to/gamedir            runs the game from the given directory which contains a main.lua file\n"
+        "    love path/to/packagedgame.love  runs the packaged game from the provided .love file\n"
+        "    love path/to/file.lua           runs the game from the given .lua file\n"
+        );
+}
+
 static DoneAction runlove(int argc, char **argv, int &retval, love::Variant &restartvalue)
 {
 	// Oh, you just want the version? Okay!
@@ -151,6 +166,13 @@ static DoneAction runlove(int argc, char **argv, int &retval, love::Variant &res
 		love_openConsole(err);
 #endif
 		printf("LOVE %s (%s)\n", love_version(), love_codename());
+		retval = 0;
+		return DONE_QUIT;
+	}
+
+	if (argc > 1 && strcmp(argv[1], "--help") == 0)
+	{
+		print_usage();
 		retval = 0;
 		return DONE_QUIT;
 	}

--- a/src/modules/love/boot.lua
+++ b/src/modules/love/boot.lua
@@ -135,6 +135,17 @@ function love.boot()
 	end
 
 	if not can_has_game then
+        -- when editing this message, change it at love.cpp too
+        print([[LÖVE is an *awesome* framework you can use to make 2D games in Lua
+https://love2d.org
+
+usage:
+    love --version                  prints LÖVE version and quits
+    love --help                     prints this message and quits
+    love path/to/gamedir            runs the game from the given directory which contains a main.lua file
+    love path/to/packagedgame.love  runs the packaged game from the provided .love file
+    love path/to/file.lua           runs the game from the given .lua file
+]]);
 		local nogame = require("love.nogame")
 		nogame()
 	end


### PR DESCRIPTION
Hi, I wanted to prepare a PR for #1735, does something like this look ok?

I added a `--help` option in the same way as there is `--version` now. It's used only when it's before a game dir or a love file, otherwise it's passed to the game arguments, example:

```
love --help #prints usage
love path/to/game --help #passed to the game
love game.love --help #passed to the game
```

I also printed usage when there is "no game" displayed, is that ok?

Could someone please check my English in the usage message (or propose a completely different wording?)

Is there a place where to put the string and use it on both places (see the diff)?

Thanks 