### PR TITLE
Fix #1834: Give MouseJoint a sensible stiffness and damping initial value

### DIFF
--- a/src/modules/physics/box2d/DistanceJoint.cpp
+++ b/src/modules/physics/box2d/DistanceJoint.cpp
@@ -56,34 +56,6 @@ float DistanceJoint::getLength() const
 	return Physics::scaleUp(joint->GetLength());
 }
 
-void DistanceJoint::setFrequency(float hz)
-{
-	float stiffness, damping;
-	b2LinearStiffness(stiffness, damping, hz, getDampingRatio(), joint->GetBodyA(), joint->GetBodyB());
-	joint->SetStiffness(stiffness);
-}
-
-float DistanceJoint::getFrequency() const
-{
-	float frequency, ratio;
-	Physics::b2LinearFrequency(frequency, ratio, joint->GetStiffness(), joint->GetDamping(), joint->GetBodyA(), joint->GetBodyB());
-	return frequency;
-}
-
-void DistanceJoint::setDampingRatio(float ratio)
-{
-	float stiffness, damping;
-	b2LinearStiffness(stiffness, damping, getFrequency(), ratio, joint->GetBodyA(), joint->GetBodyB());
-	joint->SetDamping(damping);
-}
-
-float DistanceJoint::getDampingRatio() const
-{
-	float frequency, ratio;
-	Physics::b2LinearFrequency(frequency, ratio, joint->GetStiffness(), joint->GetDamping(), joint->GetBodyA(), joint->GetBodyB());
-	return ratio;
-}
-
 void DistanceJoint::setStiffness(float k)
 {
 	joint->SetStiffness(k);

--- a/src/modules/physics/box2d/DistanceJoint.h
+++ b/src/modules/physics/box2d/DistanceJoint.h
@@ -57,26 +57,6 @@ public:
 	float getLength() const;
 
 	/**
-	 * Sets the response speed. Independent of mass
-	 **/
-	void setFrequency(float hz);
-
-	/**
-	 * Gets the response speed. Independent of mass
-	 **/
-	float getFrequency() const;
-
-	/**
-	 * Set the spring damping ratio. Independent of mass
-	 **/
-	void setDampingRatio(float ratio);
-
-	/**
-	 * Get the spring damping ratio. Independent of mass
-	 **/
-	float getDampingRatio() const;
-
-	/**
 	 * Sets the response speed. Dependent of mass
 	 **/
 	void setStiffness(float k);

--- a/src/modules/physics/box2d/MouseJoint.cpp
+++ b/src/modules/physics/box2d/MouseJoint.cpp
@@ -49,6 +49,7 @@ MouseJoint::MouseJoint(Body *body1, float x, float y)
 	def.bodyB = body1->body;
 	def.maxForce = 1000.0f * body1->body->GetMass();
 	def.target = Physics::scaleDown(b2Vec2(x,y));
+	b2LinearStiffness(def.stiffness, def.damping, 5.0f, 0.7f, def.bodyA, def.bodyB);
 	joint = (b2MouseJoint *)createJoint(&def);
 }
 

--- a/src/modules/physics/box2d/MouseJoint.cpp
+++ b/src/modules/physics/box2d/MouseJoint.cpp
@@ -49,7 +49,7 @@ MouseJoint::MouseJoint(Body *body1, float x, float y)
 	def.bodyB = body1->body;
 	def.maxForce = 1000.0f * body1->body->GetMass();
 	def.target = Physics::scaleDown(b2Vec2(x,y));
-	b2LinearStiffness(def.stiffness, def.damping, 5.0f, 0.7f, def.bodyA, def.bodyB);
+	Physics::computeLinearStiffness(def.stiffness, def.damping, 5.0, 0.7, def.bodyA, def.bodyB);
 	joint = (b2MouseJoint *)createJoint(&def);
 }
 
@@ -77,40 +77,6 @@ void MouseJoint::setMaxForce(float force)
 float MouseJoint::getMaxForce() const
 {
 	return Physics::scaleUp(joint->GetMaxForce());
-}
-
-void MouseJoint::setFrequency(float hz)
-{
-	// This is kind of a crappy check. The Stiffness is used in an internal
-	// box2d calculation whose result must be > FLT_EPSILON, but other variables
-	// go into that calculation...
-	if (hz <= FLT_EPSILON * 2)
-		throw love::Exception("MouseJoint Stiffness must be a positive number.");
-
-	float stiffness, damping;
-	b2LinearStiffness(stiffness, damping, hz, getDampingRatio(), joint->GetBodyA(), joint->GetBodyB());
-	joint->SetStiffness(stiffness);
-}
-
-float MouseJoint::getFrequency() const
-{
-	float frequency, ratio;
-	Physics::b2LinearFrequency(frequency, ratio, joint->GetStiffness(), joint->GetDamping(), joint->GetBodyA(), joint->GetBodyB());
-	return frequency;
-}
-
-void MouseJoint::setDampingRatio(float ratio)
-{
-	float stiffness, damping;
-	b2LinearStiffness(stiffness, damping, getFrequency(), ratio, joint->GetBodyA(), joint->GetBodyB());
-	joint->SetDamping(damping);
-}
-
-float MouseJoint::getDampingRatio() const
-{
-	float frequency, ratio;
-	Physics::b2LinearFrequency(frequency, ratio, joint->GetStiffness(), joint->GetDamping(), joint->GetBodyA(), joint->GetBodyB());
-	return ratio;
 }
 
 void MouseJoint::setStiffness(float k)

--- a/src/modules/physics/box2d/Physics.cpp
+++ b/src/modules/physics/box2d/Physics.cpp
@@ -405,7 +405,12 @@ b2AABB Physics::scaleUp(const b2AABB &aabb)
 	return t;
 }
 
-void Physics::b2LinearFrequency(float& frequency, float& ratio, float stiffness, float damping, b2Body* bodyA, b2Body* bodyB)
+void Physics::computeLinearStiffness(float &stiffness, float &damping, float frequency, float dampingRatio, b2Body *bodyA, b2Body *bodyB)
+{
+	b2LinearStiffness(stiffness, damping, frequency, dampingRatio, bodyA, bodyB);
+}
+
+void Physics::computeLinearFrequency(float &frequency, float &ratio, float stiffness, float damping, b2Body *bodyA, b2Body *bodyB)
 {
 	float massA = bodyA->GetMass();
 	float massB = bodyB->GetMass();
@@ -435,7 +440,12 @@ void Physics::b2LinearFrequency(float& frequency, float& ratio, float stiffness,
 	ratio = damping / (mass * 2.0f * omega);
 }
 
-void Physics::b2AngularFrequency(float& frequency, float& ratio, float stiffness, float damping, b2Body* bodyA, b2Body* bodyB)
+void Physics::computeAngularStiffness(float &stiffness, float &damping, float frequency, float dampingRatio, b2Body *bodyA, b2Body *bodyB)
+{
+	b2AngularStiffness(stiffness, damping, frequency, dampingRatio, bodyA, bodyB);
+}
+
+void Physics::computeAngularFrequency(float &frequency, float &ratio, float stiffness, float damping, b2Body *bodyA, b2Body *bodyB)
 {
 	float IA = bodyA->GetInertia();
 	float IB = bodyB->GetInertia();

--- a/src/modules/physics/box2d/Physics.h
+++ b/src/modules/physics/box2d/Physics.h
@@ -360,18 +360,18 @@ public:
 	static b2AABB scaleUp(const b2AABB& aabb);
 
 	/**
-	 * Calculates linear frequency and damping radio from stiffness and damping
-	 * @param frequency The output frequency
-	 * @param ratio The output damping ratio
-	 * @param stiffness The joint stiffness
-	 * @param damping The joint damping
+	 * Calculates the stiffness and damping, given the linear frequency, and damping ratio.
+	 * @param stiffness The output stiffness
+	 * @param damping The output damping
+	 * @param frequency The joint linear frequency
+	 * @param dampingRatio The joint damping ratio
 	 * @param bodyA The bodyA of the joint
 	 * @param bodyB The bodyB of the joint
 	 **/
-	static void b2LinearFrequency(float& frequency, float& ratio, float stiffness, float damping, b2Body* bodyA, b2Body* bodyB);
+	static void computeLinearStiffness(float& stiffness, float& damping, float frequency, float dampingRatio, b2Body* bodyA, b2Body* bodyB);
 
 	/**
-	 * Calculates angular frequency and damping radio from stiffness and damping
+	 * Calculates linear frequency and damping ratio from stiffness and damping
 	 * @param frequency The output frequency
 	 * @param ratio The output damping ratio
 	 * @param stiffness The joint stiffness
@@ -379,7 +379,29 @@ public:
 	 * @param bodyA The bodyA of the joint
 	 * @param bodyB The bodyB of the joint
 	 **/
-	static void b2AngularFrequency(float& frequency, float& ratio, float stiffness, float damping, b2Body* bodyA, b2Body* bodyB);
+	static void computeLinearFrequency(float &frequency, float &ratio, float stiffness, float damping, b2Body *bodyA, b2Body *bodyB);
+
+	/**
+	 * Calculates the stiffness and damping, given the angular frequency, and damping ratio.
+	 * @param stiffness The output stiffness
+	 * @param damping The output damping
+	 * @param frequency The joint angular frequency
+	 * @param dampingRatio The joint damping ratio
+	 * @param bodyA The bodyA of the joint
+	 * @param bodyB The bodyB of the joint
+	 **/
+	static void computeAngularStiffness(float &stiffness, float &damping, float frequency, float dampingRatio, b2Body *bodyA, b2Body *bodyB);
+
+	/**
+	 * Calculates angular frequency and damping ratio from stiffness and damping
+	 * @param frequency The output frequency
+	 * @param ratio The output damping ratio
+	 * @param stiffness The joint stiffness
+	 * @param damping The joint damping
+	 * @param bodyA The bodyA of the joint
+	 * @param bodyB The bodyB of the joint
+	 **/
+	static void computeAngularFrequency(float &frequency, float &ratio, float stiffness, float damping, b2Body *bodyA, b2Body *bodyB);
 
 private:
 

--- a/src/modules/physics/box2d/WeldJoint.cpp
+++ b/src/modules/physics/box2d/WeldJoint.cpp
@@ -66,34 +66,6 @@ void WeldJoint::init(b2WeldJointDef &def, Body *body1, Body *body2, float xA, fl
 	def.collideConnected = collideConnected;
 }
 
-void WeldJoint::setFrequency(float hz)
-{
-	float stiffness, damping;
-	b2LinearStiffness(stiffness, damping, hz, getDampingRatio(), joint->GetBodyA(), joint->GetBodyB());
-	joint->SetStiffness(stiffness);
-}
-
-float WeldJoint::getFrequency() const
-{
-	float frequency, ratio;
-	Physics::b2LinearFrequency(frequency, ratio, joint->GetStiffness(), joint->GetDamping(), joint->GetBodyA(), joint->GetBodyB());
-	return frequency;
-}
-
-void WeldJoint::setDampingRatio(float ratio)
-{
-	float stiffness, damping;
-	b2LinearStiffness(stiffness, damping, getFrequency(), ratio, joint->GetBodyA(), joint->GetBodyB());
-	joint->SetDamping(damping);
-}
-
-float WeldJoint::getDampingRatio() const
-{
-	float frequency, ratio;
-	Physics::b2LinearFrequency(frequency, ratio, joint->GetStiffness(), joint->GetDamping(), joint->GetBodyA(), joint->GetBodyB());
-	return ratio;
-}
-
 void WeldJoint::setStiffness(float k)
 {
 	joint->SetStiffness(k);

--- a/src/modules/physics/box2d/WeldJoint.h
+++ b/src/modules/physics/box2d/WeldJoint.h
@@ -50,26 +50,6 @@ public:
 	virtual ~WeldJoint();
 
 	/**
-	 * Sets the response speed. Independent of mass
-	 **/
-	void setFrequency(float hz);
-
-	/**
-	 * Gets the response speed. Independent of mass
-	 **/
-	float getFrequency() const;
-
-	/**
-	 * Set the spring damping ratio. Independent of mass
-	 **/
-	void setDampingRatio(float ratio);
-
-	/**
-	 * Get the spring damping ratio. Independent of mass
-	 **/
-	float getDampingRatio() const;
-
-	/**
 	 * Sets the response speed. Dependent of mass
 	 **/
 	void setStiffness(float k);

--- a/src/modules/physics/box2d/WheelJoint.cpp
+++ b/src/modules/physics/box2d/WheelJoint.cpp
@@ -95,34 +95,6 @@ float WheelJoint::getMotorTorque(float inv_dt) const
 	return Physics::scaleUp(Physics::scaleUp(joint->GetMotorTorque(inv_dt)));
 }
 
-void WheelJoint::setFrequency(float hz)
-{
-	float stiffness, damping;
-	b2AngularStiffness(stiffness, damping, hz, getDampingRatio(), joint->GetBodyA(), joint->GetBodyB());
-	joint->SetStiffness(stiffness);
-}
-
-float WheelJoint::getFrequency() const
-{
-	float frequency, ratio;
-	Physics::b2AngularFrequency(frequency, ratio, joint->GetStiffness(), joint->GetDamping(), joint->GetBodyA(), joint->GetBodyB());
-	return frequency;
-}
-
-void WheelJoint::setDampingRatio(float ratio)
-{
-	float stiffness, damping;
-	b2AngularStiffness(stiffness, damping, getFrequency(), ratio, joint->GetBodyA(), joint->GetBodyB());
-	joint->SetDamping(damping);
-}
-
-float WheelJoint::getDampingRatio() const
-{
-	float frequency, ratio;
-	Physics::b2AngularFrequency(frequency, ratio, joint->GetStiffness(), joint->GetDamping(), joint->GetBodyA(), joint->GetBodyB());
-	return ratio;
-}
-
 void WheelJoint::setStiffness(float k)
 {
 	joint->SetStiffness(k);

--- a/src/modules/physics/box2d/WheelJoint.h
+++ b/src/modules/physics/box2d/WheelJoint.h
@@ -96,26 +96,6 @@ public:
 	float getMotorTorque(float inv_dt) const;
 
 	/**
-	 * Sets the response speed. Independent of mass
-	 **/
-	void setFrequency(float hz);
-
-	/**
-	 * Gets the response speed. Independent of mass
-	 **/
-	float getFrequency() const;
-
-	/**
-	 * Set the spring damping ratio. Independent of mass
-	 **/
-	void setDampingRatio(float ratio);
-
-	/**
-	 * Get the spring damping ratio. Independent of mass
-	 **/
-	float getDampingRatio() const;
-
-	/**
 	 * Sets the response speed. Dependent of mass
 	 **/
 	void setStiffness(float k);

--- a/src/modules/physics/box2d/wrap_DistanceJoint.cpp
+++ b/src/modules/physics/box2d/wrap_DistanceJoint.cpp
@@ -50,36 +50,6 @@ int w_DistanceJoint_getLength(lua_State *L)
 	return 1;
 }
 
-int w_DistanceJoint_setFrequency(lua_State *L)
-{
-	DistanceJoint *t = luax_checkdistancejoint(L, 1);
-	float arg1 = (float)luaL_checknumber(L, 2);
-	t->setFrequency(arg1);
-	return 0;
-}
-
-int w_DistanceJoint_getFrequency(lua_State *L)
-{
-	DistanceJoint *t = luax_checkdistancejoint(L, 1);
-	lua_pushnumber(L, t->getFrequency());
-	return 1;
-}
-
-int w_DistanceJoint_setDampingRatio(lua_State *L)
-{
-	DistanceJoint *t = luax_checkdistancejoint(L, 1);
-	float arg1 = (float)luaL_checknumber(L, 2);
-	t->setDampingRatio(arg1);
-	return 0;
-}
-
-int w_DistanceJoint_getDampingRatio(lua_State *L)
-{
-	DistanceJoint *t = luax_checkdistancejoint(L, 1);
-	lua_pushnumber(L, t->getDampingRatio());
-	return 1;
-}
-
 int w_DistanceJoint_setStiffness(lua_State *L)
 {
 	DistanceJoint *t = luax_checkdistancejoint(L, 1);
@@ -114,10 +84,6 @@ static const luaL_Reg w_DistanceJoint_functions[] =
 {
 	{ "setLength", w_DistanceJoint_setLength },
 	{ "getLength", w_DistanceJoint_getLength },
-	{ "setFrequency", w_DistanceJoint_setFrequency },
-	{ "getFrequency", w_DistanceJoint_getFrequency },
-	{ "setDampingRatio", w_DistanceJoint_setDampingRatio },
-	{ "getDampingRatio", w_DistanceJoint_getDampingRatio },
 	{ "setStiffness", w_DistanceJoint_setStiffness },
 	{ "getStiffness", w_DistanceJoint_getStiffness },
 	{ "setDamping", w_DistanceJoint_setDamping },

--- a/src/modules/physics/box2d/wrap_MouseJoint.cpp
+++ b/src/modules/physics/box2d/wrap_MouseJoint.cpp
@@ -66,36 +66,6 @@ int w_MouseJoint_getMaxForce(lua_State *L)
 	return 1;
 }
 
-int w_MouseJoint_setFrequency(lua_State *L)
-{
-	MouseJoint *t = luax_checkmousejoint(L, 1);
-	float arg1 = (float)luaL_checknumber(L, 2);
-	luax_catchexcept(L, [&]() { t->setFrequency(arg1); });
-	return 0;
-}
-
-int w_MouseJoint_getFrequency(lua_State *L)
-{
-	MouseJoint *t = luax_checkmousejoint(L, 1);
-	lua_pushnumber(L, t->getFrequency());
-	return 1;
-}
-
-int w_MouseJoint_setDampingRatio(lua_State *L)
-{
-	MouseJoint *t = luax_checkmousejoint(L, 1);
-	float arg1 = (float)luaL_checknumber(L, 2);
-	t->setDampingRatio(arg1);
-	return 0;
-}
-
-int w_MouseJoint_getDampingRatio(lua_State *L)
-{
-	MouseJoint *t = luax_checkmousejoint(L, 1);
-	lua_pushnumber(L, t->getDampingRatio());
-	return 1;
-}
-
 int w_MouseJoint_setStiffness(lua_State *L)
 {
 	MouseJoint *t = luax_checkmousejoint(L, 1);
@@ -132,10 +102,6 @@ static const luaL_Reg w_MouseJoint_functions[] =
 	{ "getTarget", w_MouseJoint_getTarget },
 	{ "setMaxForce", w_MouseJoint_setMaxForce },
 	{ "getMaxForce", w_MouseJoint_getMaxForce },
-	{ "setFrequency", w_MouseJoint_setFrequency },
-	{ "getFrequency", w_MouseJoint_getFrequency },
-	{ "setDampingRatio", w_MouseJoint_setDampingRatio },
-	{ "getDampingRatio", w_MouseJoint_getDampingRatio },
 	{ "setStiffness", w_MouseJoint_setStiffness },
 	{ "getStiffness", w_MouseJoint_getStiffness },
 	{ "setDamping", w_MouseJoint_setDamping },

--- a/src/modules/physics/box2d/wrap_Physics.cpp
+++ b/src/modules/physics/box2d/wrap_Physics.cpp
@@ -477,10 +477,95 @@ int w_setMeter(lua_State *L)
 	return 0;
 
 }
+
 int w_getMeter(lua_State *L)
 {
 	lua_pushinteger(L, Physics::getMeter());
 	return 1;
+}
+
+int w_computeLinearStiffness(lua_State *L)
+{
+	float frequency = (float)luaL_checknumber(L, 1);
+	float dampingRatio = (float)luaL_checknumber(L, 2);
+	Body *body1 = luax_checkbody(L, 3);
+	b2Body *other = 0;
+
+	if (lua_isnoneornil(L, 4))
+		other = body1->getWorld()->getGroundBody();
+	else
+		other = luax_checkbody(L, 4)->body;
+
+	float stiffness, damping;
+	Physics::computeLinearStiffness(stiffness, damping, frequency, dampingRatio, body1->body, other);
+
+	lua_pushnumber(L, stiffness);
+	lua_pushnumber(L, damping);
+
+	return 2;
+}
+
+int w_computeLinearFrequency(lua_State *L)
+{
+	float stiffness = (float)luaL_checknumber(L, 1);
+	float damping = (float)luaL_checknumber(L, 2);
+	Body *body1 = luax_checkbody(L, 3);
+	b2Body *other = 0;
+
+	if (lua_isnoneornil(L, 4))
+		other = body1->getWorld()->getGroundBody();
+	else
+		other = luax_checkbody(L, 4)->body;
+
+	float frequency, dampingRatio;
+	Physics::computeLinearFrequency(frequency, dampingRatio, stiffness, damping, body1->body, other);
+
+	lua_pushnumber(L, frequency);
+	lua_pushnumber(L, dampingRatio);
+
+	return 2;
+}
+
+int w_computeAngularStiffness(lua_State *L)
+{
+	float frequency = (float)luaL_checknumber(L, 1);
+	float dampingRatio = (float)luaL_checknumber(L, 2);
+	Body *body1 = luax_checkbody(L, 3);
+	b2Body *other = 0;
+
+	if (lua_isnoneornil(L, 4))
+		other = body1->getWorld()->getGroundBody();
+	else
+		other = luax_checkbody(L, 4)->body;
+
+	float stiffness, damping;
+	Physics::computeAngularStiffness(stiffness, damping, frequency, dampingRatio, body1->body, other);
+
+	lua_pushnumber(L, stiffness);
+	lua_pushnumber(L, damping);
+
+	return 2;
+}
+
+int w_computeAngularFrequency(lua_State *L)
+{
+	float stiffness = (float)luaL_checknumber(L, 1);
+	float damping = (float)luaL_checknumber(L, 2);
+	Body *body1 = luax_checkbody(L, 3);
+	b2Body *other = 0;
+
+	if (lua_isnoneornil(L, 4))
+		other = body1->getWorld()->getGroundBody();
+	else
+		other = luax_checkbody(L, 4)->body;
+
+	float frequency, dampingRatio;
+	Physics::computeAngularFrequency(frequency, dampingRatio, stiffness, damping, body1->body, other);
+
+	lua_pushnumber(L, frequency);
+	lua_pushnumber(L, dampingRatio);
+
+	return 2;
 }
 
 // List of functions to wrap.
@@ -508,6 +593,10 @@ static const luaL_Reg functions[] =
 	{ "getDistance", w_getDistance },
 	{ "getMeter", w_getMeter },
 	{ "setMeter", w_setMeter },
+	{ "computeLinearStiffness", w_computeLinearStiffness },
+	{ "computeLinearFrequency", w_computeLinearFrequency },
+	{ "computeAngularStiffness", w_computeAngularStiffness },
+	{ "computeAngularFrequency", w_computeAngularFrequency },
 	{ 0, 0 },
 };
 

--- a/src/modules/physics/box2d/wrap_WeldJoint.cpp
+++ b/src/modules/physics/box2d/wrap_WeldJoint.cpp
@@ -35,36 +35,6 @@ WeldJoint *luax_checkweldjoint(lua_State *L, int idx)
 	return j;
 }
 
-int w_WeldJoint_setFrequency(lua_State *L)
-{
-	WeldJoint *t = luax_checkweldjoint(L, 1);
-	float arg1 = (float)luaL_checknumber(L, 2);
-	t->setFrequency(arg1);
-	return 0;
-}
-
-int w_WeldJoint_getFrequency(lua_State *L)
-{
-	WeldJoint *t = luax_checkweldjoint(L, 1);
-	lua_pushnumber(L, t->getFrequency());
-	return 1;
-}
-
-int w_WeldJoint_setDampingRatio(lua_State *L)
-{
-	WeldJoint *t = luax_checkweldjoint(L, 1);
-	float arg1 = (float)luaL_checknumber(L, 2);
-	t->setDampingRatio(arg1);
-	return 0;
-}
-
-int w_WeldJoint_getDampingRatio(lua_State *L)
-{
-	WeldJoint *t = luax_checkweldjoint(L, 1);
-	lua_pushnumber(L, t->getDampingRatio());
-	return 1;
-}
-
 int w_WeldJoint_setStiffness(lua_State *L)
 {
 	WeldJoint *t = luax_checkweldjoint(L, 1);
@@ -104,10 +74,6 @@ int w_WeldJoint_getReferenceAngle(lua_State *L)
 
 static const luaL_Reg w_WeldJoint_functions[] =
 {
-	{ "setFrequency", w_WeldJoint_setFrequency },
-	{ "getFrequency", w_WeldJoint_getFrequency },
-	{ "setDampingRatio", w_WeldJoint_setDampingRatio },
-	{ "getDampingRatio", w_WeldJoint_getDampingRatio },
 	{ "setStiffness", w_WeldJoint_setStiffness },
 	{ "getStiffness", w_WeldJoint_getStiffness },
 	{ "setDamping", w_WeldJoint_setDamping },

--- a/src/modules/physics/box2d/wrap_WheelJoint.cpp
+++ b/src/modules/physics/box2d/wrap_WheelJoint.cpp
@@ -102,36 +102,6 @@ int w_WheelJoint_getMotorTorque(lua_State *L)
 	return 1;
 }
 
-int w_WheelJoint_setFrequency(lua_State *L)
-{
-	WheelJoint *t = luax_checkwheeljoint(L, 1);
-	float arg1 = (float)luaL_checknumber(L, 2);
-	t->setFrequency(arg1);
-	return 0;
-}
-
-int w_WheelJoint_getFrequency(lua_State *L)
-{
-	WheelJoint *t = luax_checkwheeljoint(L, 1);
-	lua_pushnumber(L, t->getFrequency());
-	return 1;
-}
-
-int w_WheelJoint_setDampingRatio(lua_State *L)
-{
-	WheelJoint *t = luax_checkwheeljoint(L, 1);
-	float arg1 = (float)luaL_checknumber(L, 2);
-	t->setDampingRatio(arg1);
-	return 0;
-}
-
-int w_WheelJoint_getDampingRatio(lua_State *L)
-{
-	WheelJoint *t = luax_checkwheeljoint(L, 1);
-	lua_pushnumber(L, t->getDampingRatio());
-	return 1;
-}
-
 int w_WheelJoint_setStiffness(lua_State *L)
 {
 	WheelJoint *t = luax_checkwheeljoint(L, 1);
@@ -180,18 +150,10 @@ static const luaL_Reg w_WheelJoint_functions[] =
 	{ "setMaxMotorTorque", w_WheelJoint_setMaxMotorTorque },
 	{ "getMaxMotorTorque", w_WheelJoint_getMaxMotorTorque },
 	{ "getMotorTorque", w_WheelJoint_getMotorTorque },
-	{ "setSpringFrequency", w_WheelJoint_setFrequency },
-	{ "getSpringFrequency", w_WheelJoint_getFrequency },
-	{ "setSpringDampingRatio", w_WheelJoint_setDampingRatio },
-	{ "getSpringDampingRatio", w_WheelJoint_getDampingRatio },
 	{ "setSpringStiffness", w_WheelJoint_setStiffness },
 	{ "getSpringStiffness", w_WheelJoint_getStiffness },
 	{ "setSpringDamping", w_WheelJoint_setDamping },
 	{ "getSpringDamping", w_WheelJoint_getDamping },
-	{ "setFrequency", w_WheelJoint_setFrequency },
-	{ "getFrequency", w_WheelJoint_getFrequency },
-	{ "setDampingRatio", w_WheelJoint_setDampingRatio },
-	{ "getDampingRatio", w_WheelJoint_getDampingRatio },
 	{ "setStiffness", w_WheelJoint_setStiffness },
 	{ "getStiffness", w_WheelJoint_getStiffness },
 	{ "setDamping", w_WheelJoint_setDamping },


### PR DESCRIPTION
As it says on the tin, this is two commits to fix the behaviour in #1834. The first fixes it with minimal changes (by setting the default values from before), and the second is a draft of a more significant change

[Box2d 2.4.0 converted all its joints to use stiffness and damping](https://github.com/erincatto/box2d/blob/main/CHANGELOG.md#dynamics), rather than the old spring-damper, which meant that the springy-ness is defined by `stiffness`, rather than `frequency`. They provided a helper function for linear and angular stiffness to convert from the old way to the new way

When https://github.com/love2d/love/pull/1613 was merged, thegrb93 helpfully added in some conversion steps to continue taking the frequency/damping values, and under the hood use the helper functions to convert them to stiffness (as well as exposing getters and setters for `stiffness` and `damping`)

`love.physics` has (in my experience) been pretty close to the actual Box2d API, just with a few helpers. It's kinda helpful being so close, as it means you can often find materials talking about Box2d, and easily apply it to love. In that sense, rather than keeping both spring physics as functions on Joints, just expose conversions at the top `love.physics` level, and then use that to set values on the joints via setters:

```lua
local joint = love.physics.newMouseJoint(body, love.mouse.getPosition())
local stiffness, damping = love.physics.linearStiffness(5.0, 0.7, body)
joint:setStiffness(stiffness)
joint:setDamping(damping)
```

This is kinda nice, because it isolates the variation to one spot, rather than on each joint, so further API changes are minimal, I guess.

I'm more seeking feedback on the approach - I've marked it as a `Draft` because honestly? I'm not sold on it, so I'm keen for feedback (and happy to drop it if we want). On top of that, there are any C++ changes, lemme know ('cause this is the most I've written ehe)

