### PR TITLE
fix: remove usage of setNewFont on error handler

### DIFF
--- a/src/modules/love/callbacks.lua
+++ b/src/modules/love/callbacks.lua
@@ -232,7 +232,8 @@ function love.errhand(msg)
 	if love.audio then love.audio.stop() end
 
 	love.graphics.reset()
-	local font = love.graphics.setNewFont(14)
+	local font = love.graphics.newFont(14)
+	love.graphics.setFont(font)
 
 	love.graphics.setColor(1, 1, 1)
 


### PR DESCRIPTION
As it says on the tin.

`love.graphics.setNewFont` is deprecated.

Before:
![image](https://user-images.githubusercontent.com/7221020/205473483-00ee9fa5-b58e-4a75-876b-b1414828bd82.png)

After:
![image](https://user-images.githubusercontent.com/7221020/205473489-ad76f842-ab4f-4767-bc30-b6bf890fdbd2.png)

