### PR TITLE
Bump minimum SDL version to 2.0.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ Please see https://github.com/love2d/megasource
 	find_package(ModPlug REQUIRED)
 	find_package(OpenAL REQUIRED)
 	find_package(OpenGL REQUIRED)
-	find_package(SDL2 REQUIRED)
+	find_package(SDL2 2.0.9 REQUIRED)
 	find_package(Theora REQUIRED)
 	find_package(Vorbis REQUIRED)
 	find_package(ZLIB REQUIRED)

--- a/platform/unix/deps.m4
+++ b/platform/unix/deps.m4
@@ -21,7 +21,7 @@ AC_DEFUN([ACLOVE_DEP_LIBM], [
 
 AC_DEFUN([ACLOVE_DEP_SDL2], [
 	aclove_sdl2_found=no
-	AM_PATH_SDL2([], [aclove_sdl2_found=yes], [])
+	AM_PATH_SDL2([2.0.9], [aclove_sdl2_found=yes], [])
 	AS_VAR_IF([aclove_sdl2_found], [no], [LOVE_MSG_ERROR([SDL 2])], [])])
 
 AC_DEFUN([ACLOVE_DEP_PTHREAD], [

--- a/src/modules/event/sdl/Event.cpp
+++ b/src/modules/event/sdl/Event.cpp
@@ -193,10 +193,6 @@ Message *Event::convert(const SDL_Event &e)
 	love::touch::Touch::TouchInfo touchinfo;
 #endif
 
-#ifdef LOVE_LINUX
-	static bool touchNormalizationBug = false;
-#endif
-
 	switch (e.type)
 	{
 	case SDL_KEYDOWN:
@@ -315,22 +311,9 @@ Message *Event::convert(const SDL_Event &e)
 		touchinfo.dy = e.tfinger.dy;
 		touchinfo.pressure = e.tfinger.pressure;
 
-#ifdef LOVE_LINUX
-		// FIXME: hacky workaround for SDL not normalizing touch coordinates in
-		// its X11 backend: https://bugzilla.libsdl.org/show_bug.cgi?id=2307
-		if (touchNormalizationBug || fabs(touchinfo.x) >= 1.5 || fabs(touchinfo.y) >= 1.5 || fabs(touchinfo.dx) >= 1.5 || fabs(touchinfo.dy) >= 1.5)
-		{
-			touchNormalizationBug = true;
-			windowToDPICoords(&touchinfo.x, &touchinfo.y);
-			windowToDPICoords(&touchinfo.dx, &touchinfo.dy);
-		}
-		else
-#endif
-		{
-			// SDL's coords are normalized to [0, 1], but we want screen coords.
-			normalizedToDPICoords(&touchinfo.x, &touchinfo.y);
-			normalizedToDPICoords(&touchinfo.dx, &touchinfo.dy);
-		}
+		// SDL's coords are normalized to [0, 1], but we want screen coords.
+		normalizedToDPICoords(&touchinfo.x, &touchinfo.y);
+		normalizedToDPICoords(&touchinfo.dx, &touchinfo.dy);
 
 		// We need to update the love.touch.sdl internal state from here.
 		touchmodule = (touch::sdl::Touch *) Module::getInstance("love.touch.sdl");

--- a/src/modules/event/sdl/Event.cpp
+++ b/src/modules/event/sdl/Event.cpp
@@ -374,7 +374,6 @@ Message *Event::convert(const SDL_Event &e)
 	case SDL_WINDOWEVENT:
 		msg = convertWindowEvent(e);
 		break;
-#if SDL_VERSION_ATLEAST(2, 0, 9)
 	case SDL_DISPLAYEVENT:
 		if (e.display.event == SDL_DISPLAYEVENT_ORIENTATION)
 		{
@@ -408,7 +407,6 @@ Message *Event::convert(const SDL_Event &e)
 			msg = new Message("displayrotated", vargs);
 		}
 		break;
-#endif
 	case SDL_DROPFILE:
 		filesystem = Module::getInstance<filesystem::Filesystem>(Module::M_FILESYSTEM);
 		if (filesystem != nullptr)

--- a/src/modules/joystick/sdl/Joystick.cpp
+++ b/src/modules/joystick/sdl/Joystick.cpp
@@ -413,7 +413,6 @@ int Joystick::getID() const
 
 void Joystick::getDeviceInfo(int &vendorID, int &productID, int &productVersion) const
 {
-#if SDL_VERSION_ATLEAST(2, 0, 6)
 	if (joyhandle != nullptr)
 	{
 		vendorID = SDL_JoystickGetVendor(joyhandle);
@@ -421,7 +420,6 @@ void Joystick::getDeviceInfo(int &vendorID, int &productID, int &productVersion)
 		productVersion = SDL_JoystickGetProductVersion(joyhandle);
 	}
 	else
-#endif
 	{
 		vendorID = 0;
 		productID = 0;
@@ -525,10 +523,8 @@ bool Joystick::setVibration(float left, float right, float duration)
 
 	bool success = false;
 
-#if SDL_VERSION_ATLEAST(2, 0, 9)
 	if (SDL_JoystickRumble(joyhandle, (Uint16)(left * LOVE_UINT16_MAX), (Uint16)(right * LOVE_UINT16_MAX), length) == 0)
 		success = true;
-#endif
 
 	if (!success && !checkCreateHaptic())
 		return false;
@@ -610,10 +606,8 @@ bool Joystick::setVibration()
 {
 	bool success = false;
 
-#if SDL_VERSION_ATLEAST(2, 0, 9)
 	if (!success)
 		success = isConnected() && SDL_JoystickRumble(joyhandle, 0, 0, 0) == 0;
-#endif
 
 	if (!success && SDL_WasInit(SDL_INIT_HAPTIC) && haptic && SDL_HapticIndex(haptic) != -1)
 		success = (SDL_HapticStopEffect(haptic, vibration.id) == 0);

--- a/src/modules/window/sdl/Window.cpp
+++ b/src/modules/window/sdl/Window.cpp
@@ -588,12 +588,8 @@ bool Window::setWindow(int width, int height, WindowSettings *settings)
 		if (!f.fullscreen)
 			SDL_SetWindowSize(window, width, height);
 
-		// On linux systems 2.0.5+ might not be available...
-		// TODO: require at least 2.0.5?
-#if SDL_VERSION_ATLEAST(2, 0, 5)
 		if (this->settings.resizable != f.resizable)
 			SDL_SetWindowResizable(window, f.resizable ? SDL_TRUE : SDL_FALSE);
-#endif
 
 		if (this->settings.borderless != f.borderless)
 			SDL_SetWindowBordered(window, f.borderless ? SDL_FALSE : SDL_TRUE);
@@ -909,9 +905,6 @@ const char *Window::getDisplayName(int displayindex) const
 
 Window::DisplayOrientation Window::getDisplayOrientation(int displayindex) const
 {
-	// TODO: We can expose this everywhere, we just need to watch out for the
-	// SDL binary being older than the headers on Linux.
-#if SDL_VERSION_ATLEAST(2, 0, 9) && (defined(LOVE_ANDROID) || !defined(LOVE_LINUX))
 	switch (SDL_GetDisplayOrientation(displayindex))
 	{
 		case SDL_ORIENTATION_UNKNOWN: return ORIENTATION_UNKNOWN;
@@ -920,9 +913,6 @@ Window::DisplayOrientation Window::getDisplayOrientation(int displayindex) const
 		case SDL_ORIENTATION_PORTRAIT: return ORIENTATION_PORTRAIT;
 		case SDL_ORIENTATION_PORTRAIT_FLIPPED: return ORIENTATION_PORTRAIT_FLIPPED;
 	}
-#else
-	LOVE_UNUSED(displayindex);
-#endif
 
 	return ORIENTATION_UNKNOWN;
 }


### PR DESCRIPTION
Historically LOVE only requires at least SDL 2.0.0 to build, forcing new functionality that require certain SDL versions to be kept around `SDL_VERSION_ATLEAST` macro. However, this makes LOVE build crippled when someone compiles with older SDL.

Furthermore with the addition of the `love.sensor` module (#1873), we have to trade between requiring at least certain SDL version or lacking `love.sensor` module completely in their LOVE build.

After some discussion in Discord, it's been agreed to bump required LOVE minimum SDL version to 2.0.9. This PR cleanup some `SDL_VERSION_ATLEAST` macro, up to SDL 2.0.9.

I also clean up the touch coordinate normalization workaround code in Linux as I don't think it's needed anymore. I checked the original issue (libsdl-org/SDL#2656) and it's been fixed since SDL 2.0.7.