### PR TITLE
Prefer snprintf over sprintf in OpenGL

### DIFF
--- a/src/modules/graphics/opengl/OpenGL.cpp
+++ b/src/modules/graphics/opengl/OpenGL.cpp
@@ -1937,8 +1937,7 @@ const char *OpenGL::errorString(GLenum errorcode)
 
 	static char text[64] = {};
 
-	memset(text, 0, sizeof(text));
-	sprintf(text, "0x%x", errorcode);
+	snprintf(text, sizeof(text), "0x%x", errorcode);
 
 	return text;
 }
@@ -1967,8 +1966,7 @@ const char *OpenGL::framebufferStatusString(GLenum status)
 
 	static char text[64] = {};
 
-	memset(text, 0, sizeof(text));
-	sprintf(text, "0x%x", status);
+	snprintf(text, sizeof(text), "0x%x", status);
 
 	return text;
 }


### PR DESCRIPTION
Silences warnings about deprecated sprintf under Xcode 14