### PR TITLE
Prefer snprintf over sprintf in OpenGL

### DIFF
--- a/src/modules/graphics/opengl/OpenGL.cpp
+++ b/src/modules/graphics/opengl/OpenGL.cpp
@@ -2420,8 +2420,7 @@ const char *OpenGL::errorString(GLenum errorcode)
 
 	static char text[64] = {};
 
-	memset(text, 0, sizeof(text));
-	sprintf(text, "0x%x", errorcode);
+	snprintf(text, sizeof(text), "0x%x", errorcode);
 
 	return text;
 }
@@ -2450,8 +2449,7 @@ const char *OpenGL::framebufferStatusString(GLenum status)
 
 	static char text[64] = {};
 
-	memset(text, 0, sizeof(text));
-	sprintf(text, "0x%x", status);
+	snprintf(text, sizeof(text), "0x%x", status);
 
 	return text;
 }


### PR DESCRIPTION
Silence warnings against sprintf in OpenGL module. Acceptable since compilers used for love 12 have snprintf. 