### PR TITLE
Move all remaining instances of sprintf to snprintf.

### DIFF
--- a/src/libraries/luasocket/libluasocket/auxiliar.c
+++ b/src/libraries/luasocket/libluasocket/auxiliar.c
@@ -51,7 +51,7 @@ int auxiliar_tostring(lua_State *L) {
     lua_pushstring(L, "class");
     lua_gettable(L, -2);
     if (!lua_isstring(L, -1)) goto error;
-    sprintf(buf, "%p", lua_touserdata(L, 1));
+    snprintf(buf, sizeof(buf), "%p", lua_touserdata(L, 1));
     lua_pushfstring(L, "%s: %s", lua_tostring(L, -1), buf);
     return 1;
 error:
@@ -88,7 +88,7 @@ void *auxiliar_checkclass(lua_State *L, const char *classname, int objidx) {
     void *data = auxiliar_getclassudata(L, classname, objidx);
     if (!data) {
         char msg[45];
-        sprintf(msg, "%.35s expected", classname);
+        snprintf(msg, sizeof(msg), "%.35s expected", classname);
         luaL_argerror(L, objidx, msg);
     }
     return data;
@@ -102,7 +102,7 @@ void *auxiliar_checkgroup(lua_State *L, const char *groupname, int objidx) {
     void *data = auxiliar_getgroupudata(L, groupname, objidx);
     if (!data) {
         char msg[45];
-        sprintf(msg, "%.35s expected", groupname);
+        snprintf(msg, sizeof(msg), "%.35s expected", groupname);
         luaL_argerror(L, objidx, msg);
     }
     return data;

--- a/src/libraries/luasocket/libluasocket/options.c
+++ b/src/libraries/luasocket/libluasocket/options.c
@@ -35,7 +35,7 @@ int opt_meth_setoption(lua_State *L, p_opt opt, p_socket ps)
         opt++;
     if (!opt->func) {
         char msg[57];
-        sprintf(msg, "unsupported option `%.35s'", name);
+        snprintf(msg, sizeof(msg), "unsupported option `%.35s'", name);
         luaL_argerror(L, 2, msg);
     }
     return opt->func(L, ps);
@@ -48,7 +48,7 @@ int opt_meth_getoption(lua_State *L, p_opt opt, p_socket ps)
         opt++;
     if (!opt->func) {
         char msg[57];
-        sprintf(msg, "unsupported option `%.35s'", name);
+        snprintf(msg, sizeof(msg), "unsupported option `%.35s'", name);
         luaL_argerror(L, 2, msg);
     }
     return opt->func(L, ps);

--- a/src/libraries/spirv_cross/spirv_common.hpp
+++ b/src/libraries/spirv_cross/spirv_common.hpp
@@ -238,16 +238,6 @@ static inline std::string convert_to_string(int64_t value, const std::string &in
 #define SPIRV_CROSS_FLT_FMT "%.32g"
 #endif
 
-// Disable sprintf and strcat warnings.
-// We cannot rely on snprintf and family existing because, ..., MSVC.
-#if defined(__clang__) || defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-
 static inline void fixup_radix_point(char *str, char radix_point)
 {
 	// Setting locales is a very risky business in multi-threaded program,
@@ -268,7 +258,7 @@ inline std::string convert_to_string(float t, char locale_radix_point)
 	// std::to_string for floating point values is broken.
 	// Fallback to something more sane.
 	char buf[64];
-	sprintf(buf, SPIRV_CROSS_FLT_FMT, t);
+	snprintf(buf, sizeof(buf), SPIRV_CROSS_FLT_FMT, t);
 	fixup_radix_point(buf, locale_radix_point);
 
 	// Ensure that the literal is float.
@@ -282,7 +272,7 @@ inline std::string convert_to_string(double t, char locale_radix_point)
 	// std::to_string for floating point values is broken.
 	// Fallback to something more sane.
 	char buf[64];
-	sprintf(buf, SPIRV_CROSS_FLT_FMT, t);
+	snprintf(buf, sizeof(buf), SPIRV_CROSS_FLT_FMT, t);
 	fixup_radix_point(buf, locale_radix_point);
 
 	// Ensure that the literal is float.
@@ -313,12 +303,6 @@ struct ValueSaver
 	T &current;
 	T saved;
 };
-
-#if defined(__clang__) || defined(__GNUC__)
-#pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 
 struct Instruction
 {

--- a/src/libraries/spirv_cross/spirv_glsl.cpp
+++ b/src/libraries/spirv_cross/spirv_glsl.cpp
@@ -4998,13 +4998,6 @@ string CompilerGLSL::constant_expression(const SPIRConstant &c)
 	}
 }
 
-#ifdef _MSC_VER
-// sprintf warning.
-// We cannot rely on snprintf existing because, ..., MSVC.
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-
 string CompilerGLSL::convert_half_to_string(const SPIRConstant &c, uint32_t col, uint32_t row)
 {
 	string res;
@@ -5060,7 +5053,7 @@ string CompilerGLSL::convert_float_to_string(const SPIRConstant &c, uint32_t col
 			in_type.width = 32;
 
 			char print_buffer[32];
-			sprintf(print_buffer, "0x%xu", c.scalar(col, row));
+			snprintf(print_buffer, sizeof(print_buffer), "0x%xu", c.scalar(col, row));
 
 			const char *comment = "inf";
 			if (float_value == -numeric_limits<float>::infinity())
@@ -5132,7 +5125,7 @@ std::string CompilerGLSL::convert_double_to_string(const SPIRConstant &c, uint32
 			require_extension_internal("GL_ARB_gpu_shader_int64");
 
 			char print_buffer[64];
-			sprintf(print_buffer, "0x%llx%s", static_cast<unsigned long long>(u64_value),
+			snprintf(print_buffer, sizeof(print_buffer), "0x%llx%s", static_cast<unsigned long long>(u64_value),
 			        backend.long_long_literal_suffix ? "ull" : "ul");
 
 			const char *comment = "inf";

--- a/src/libraries/spirv_cross/spirv_msl.cpp
+++ b/src/libraries/spirv_cross/spirv_msl.cpp
@@ -16172,6 +16172,6 @@ void CompilerMSL::emit_block_hints(const SPIRBlock &)
 string CompilerMSL::additional_fixed_sample_mask_str() const
 {
 	char print_buffer[32];
-	sprintf(print_buffer, "0x%x", msl_options.additional_fixed_sample_mask);
+	snprintf(print_buffer, sizeof(print_buffer),"0x%x", msl_options.additional_fixed_sample_mask);
 	return print_buffer;
 }


### PR DESCRIPTION
Remove all remaining calls to sprintf in favor of modern snprintf. 