### PR TITLE
Compile with hidden symbol visibility by default.

### DIFF
--- a/platform/unix/configure.ac
+++ b/platform/unix/configure.ac
@@ -29,6 +29,10 @@ AC_DEFUN([LOVE_MSG_ERROR],
 # C++11 support in cpp11.m4
 ACLOVE_CPP11_TEST
 
+# Add -fvisibility=hidden and -fvisibility-inlines-hidden
+CFLAGS="-fvisibility=hidden $CFLAGS"
+CPPFLAGS="-fvisibility=hidden -fvisibility-inlines-hidden $CPPFLAGS"
+
 # Allow people on OSX to use autotools, they need their platform files
 AC_ARG_ENABLE([osx],
 			  AC_HELP_STRING([--enable-osx], [Compile platform-specific files for OSX]), [], [enable_osx=no])

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -104,8 +104,10 @@
 #endif
 
 // DLL-stuff.
-#ifdef LOVE_WINDOWS
+#if defined(_MSC_VER)
 #	define LOVE_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#	define LOVE_EXPORT __attribute__((visibility("default")))
 #else
 #	define LOVE_EXPORT
 #endif


### PR DESCRIPTION
This also benefits main branch so I'm targetting main branch instead of 12.0.