### PR TITLE
Allow Canvas:renderTo to accept varargs

### DIFF
--- a/src/modules/graphics/wrap_Canvas.cpp
+++ b/src/modules/graphics/wrap_Canvas.cpp
@@ -42,6 +42,8 @@ int w_Canvas_renderTo(lua_State *L)
 {
 	Graphics::RenderTarget rt(luax_checkcanvas(L, 1));
 
+	int args = lua_gettop(L);
+
 	int startidx = 2;
 
 	if (rt.canvas->getTextureType() != TEXTURE_2D)
@@ -67,8 +69,7 @@ int w_Canvas_renderTo(lua_State *L)
 
 		luax_catchexcept(L, [&](){ graphics->setCanvas(rt, false); });
 
-		lua_settop(L, 2); // make sure the function is on top of the stack
-		int status = lua_pcall(L, 0, 0, 0);
+		int status = lua_pcall(L, args - startidx, 0, 0);
 
 		graphics->setCanvas(oldtargets);
 


### PR DESCRIPTION
In many cases, `Canvas:renderTo` would have been much more useful to me if it could accept additional parameters - without them, you're forced to make a new function if you want it to do something slightly different.
Accepting varargs can let you make the same function do different things without having to create a new one, which can save on a lot of garbage creation.