### PR TITLE
Add 'background' boolean (false by default) to love.window.setMode's …

### DIFF
--- a/src/modules/love/boot.lua
+++ b/src/modules/love/boot.lua
@@ -148,6 +148,7 @@ function love.init()
 			centered = true,
 			highdpi = false,
 			usedpiscale = true,
+			background = false,
 		},
 		modules = {
 			data = true,
@@ -295,6 +296,7 @@ function love.init()
 			display = c.window.display,
 			highdpi = c.window.highdpi,
 			usedpiscale = c.window.usedpiscale,
+			background = c.window.background,
 			x = c.window.x,
 			y = c.window.y,
 		}), "Could not set window mode")

--- a/src/modules/window/Window.cpp
+++ b/src/modules/window/Window.cpp
@@ -105,6 +105,7 @@ StringMap<Window::Setting, Window::SETTING_MAX_ENUM>::Entry Window::settingEntri
 	{"display", SETTING_DISPLAY},
 	{"highdpi", SETTING_HIGHDPI},
 	{"usedpiscale", SETTING_USE_DPISCALE},
+	{"background", SETTING_BACKGROUND},
 	{"refreshrate", SETTING_REFRESHRATE},
 	{"x", SETTING_X},
 	{"y", SETTING_Y},

--- a/src/modules/window/Window.h
+++ b/src/modules/window/Window.h
@@ -68,6 +68,7 @@ public:
 		SETTING_DISPLAY,
 		SETTING_HIGHDPI,
 		SETTING_USE_DPISCALE,
+		SETTING_BACKGROUND,
 		SETTING_REFRESHRATE,
 		SETTING_X,
 		SETTING_Y,
@@ -263,6 +264,7 @@ struct WindowSettings
 	int display = 0;
 	bool highdpi = false;
 	bool usedpiscale = true;
+	bool background = false;
 	double refreshrate = 0.0;
 	bool useposition = false;
 	int x = 0;

--- a/src/modules/window/sdl/Window.cpp
+++ b/src/modules/window/sdl/Window.cpp
@@ -509,6 +509,9 @@ bool Window::setWindow(int width, int height, WindowSettings *settings)
 
 	close();
 
+	if(f.background)
+		SDL_SetHint(SDL_HINT_MAC_BACKGROUND_APP,"1");
+
 	if (!createWindowAndContext(x, y, width, height, sdlflags, f.msaa, f.stencil, f.depth))
 		return false;
 
@@ -524,7 +527,10 @@ bool Window::setWindow(int width, int height, WindowSettings *settings)
 	if (f.useposition || f.centered)
 		SDL_SetWindowPosition(window, x, y);
 
-	SDL_RaiseWindow(window);
+	if(f.background)
+		SDL_ShowWindow(window);
+	else
+		SDL_RaiseWindow(window);
 
 	setVSync(f.vsync);
 
@@ -607,6 +613,7 @@ void Window::updateSettings(const WindowSettings &newsettings, bool updateGraphi
 
 	settings.highdpi = (wflags & SDL_WINDOW_ALLOW_HIGHDPI) != 0;
 	settings.usedpiscale = newsettings.usedpiscale;
+	settings.background = newsettings.background;
 
 	// Only minimize on focus loss if the window is in exclusive-fullscreen mode
 	if (settings.fullscreen && settings.fstype == FULLSCREEN_EXCLUSIVE)

--- a/src/modules/window/wrap_Window.cpp
+++ b/src/modules/window/wrap_Window.cpp
@@ -77,6 +77,7 @@ static int readWindowSettings(lua_State *L, int idx, WindowSettings &settings)
 	settings.display = luax_intflag(L, idx, settingName(Window::SETTING_DISPLAY), settings.display+1) - 1;
 	settings.highdpi = luax_boolflag(L, idx, settingName(Window::SETTING_HIGHDPI), settings.highdpi);
 	settings.usedpiscale = luax_boolflag(L, idx, settingName(Window::SETTING_USE_DPISCALE), settings.usedpiscale);
+	settings.background = luax_boolflag(L, idx, settingName(Window::SETTING_BACKGROUND), settings.background);
 
 	lua_getfield(L, idx, settingName(Window::SETTING_VSYNC));
 	if (lua_isnumber(L, -1))
@@ -206,6 +207,9 @@ int w_getMode(lua_State *L)
 
 	luax_pushboolean(L, settings.usedpiscale);
 	lua_setfield(L, -2, settingName(Window::SETTING_USE_DPISCALE));
+
+	lua_pushboolean(L, settings.background);
+	lua_setfield(L, -2, settingName(Window::SETTING_BACKGROUND));
 
 	lua_pushnumber(L, settings.refreshrate);
 	lua_setfield(L, -2, settingName(Window::SETTING_REFRESHRATE));


### PR DESCRIPTION
…settings table and love.conf's t.window table.

When background=true, love will no longer automatically raise the window and make it active on creation, but show it in background instead.

-----

I have a specific workflow where i have a love2d window in background while i edit source code in a terminal window and love2d will get automatically brought down and started again once changes are saved. This commit will make it so program's window won't jump into foreground and steal focus from my editor of choice. Not sure if it is useful enough in general but just in case.

Only tested on OSX, but should work elsewhere, probably.
