### PR TITLE
graphics: fix for anti-parallel line segments

### DIFF
--- a/src/modules/graphics/Polyline.cpp
+++ b/src/modules/graphics/Polyline.cpp
@@ -157,7 +157,7 @@ void NoneJoinPolyline::renderEdge(std::vector<Vector2> &anchors, std::vector<Vec
  *    (q + w/2 * ns) + lambda * (q - p) = (q + w/2 * nt) + mu * (r - q)   (u1)
  *    (q - w/2 * ns) + lambda * (q - p) = (q - w/2 * nt) + mu * (r - q)   (u2)
  *
- * with nt,nt being the normals on the segments s = p-q and t = q-r,
+ * with ns,nt being the normals on the segments s = p-q and t = q-r,
  *
  *    ns = perp(s) / |s|
  *    nt = perp(t) / |t|.

--- a/src/modules/graphics/Polyline.cpp
+++ b/src/modules/graphics/Polyline.cpp
@@ -188,11 +188,26 @@ void MiterJoinPolyline::renderEdge(std::vector<Vector2> &anchors, std::vector<Ve
 	anchors.push_back(pointA);
 
 	float det = Vector2::cross(segment, newSegment);
-	if (fabs(det) / (segmentLength * newSegmentLength) < LINES_PARALLEL_EPS && Vector2::dot(segment, newSegment) > 0)
+	if (fabs(det) / (segmentLength * newSegmentLength) < LINES_PARALLEL_EPS)
 	{
 		// lines parallel, compute as u1 = q + ns * w/2, u2 = q - ns * w/2
 		normals.push_back(segmentNormal);
 		normals.push_back(-segmentNormal);
+
+		if (Vector2::dot(segment, newSegment) < 0)
+		{
+			// line reverses direction; because the normal flips, the
+			// triangle strip would twist here, so insert a zero-size
+			// quad to contain the twist
+			//  ____.___.____
+			// |    |\ /|    |
+			// p    q X q    r
+			// |____|/ \|____|
+			anchors.push_back(pointA);
+			anchors.push_back(pointA);
+			normals.push_back(-segmentNormal);
+			normals.push_back(segmentNormal);
+		}
 	}
 	else
 	{
@@ -233,14 +248,24 @@ void BevelJoinPolyline::renderEdge(std::vector<Vector2> &anchors, std::vector<Ve
 	float newSegmentLength = newSegment.getLength();
 
 	float det = Vector2::cross(segment, newSegment);
-	if (fabs(det) / (segmentLength * newSegmentLength) < LINES_PARALLEL_EPS && Vector2::dot(segment, newSegment) > 0)
+	if (fabs(det) / (segmentLength * newSegmentLength) < LINES_PARALLEL_EPS)
 	{
 		// lines parallel, compute as u1 = q + ns * w/2, u2 = q - ns * w/2
 		Vector2 newSegmentNormal = newSegment.getNormal(halfWidth / newSegmentLength);
 		anchors.push_back(pointA);
 		anchors.push_back(pointA);
-		normals.push_back(newSegmentNormal);
-		normals.push_back(-newSegmentNormal);
+		normals.push_back(segmentNormal);
+		normals.push_back(-segmentNormal);
+
+		if (Vector2::dot(segment, newSegment) < 0)
+		{
+			// line reverses direction; same as for miter
+			anchors.push_back(pointA);
+			anchors.push_back(pointA);
+			normals.push_back(-segmentNormal);
+			normals.push_back(segmentNormal);
+		}
+
 		segment = newSegment;
 		segmentLength = newSegmentLength;
 		segmentNormal = newSegmentNormal;


### PR DESCRIPTION
Fixes #1894.

Correctly handles the case where a line doubles back on itself. For both miter and bevel, the line will be drawn like this (angle increased for readability; in reality the angle pqr would be much smaller of course)

![](https://user-images.githubusercontent.com/11024420/220519539-1d77430d-2e28-40e0-ac16-41d1312e8198.png)

Because the normal flips here, the triangle strip would twist. So to draw this we "contain" the twist in an invisible zero-size quad

![join2](https://user-images.githubusercontent.com/11024420/220519729-57872f0b-9ecb-4a65-b6b4-0952f47d642d.png)

Here's an example showing the importance of the twist correction

```lua
function love.draw()
    love.graphics.setLineWidth(20)
    love.graphics.setLineJoin("miter")
    love.graphics.line({
        190, 200,
        200, 200,
        100, 200
    })
    love.graphics.setLineJoin("bevel")
    love.graphics.line({
        100, 300,
        200, 300,
        190, 300
    })
end
```

![](https://user-images.githubusercontent.com/11024420/220521365-08330bd1-ba1a-402f-bab8-26246cba795d.png)

