### PR TITLE
Added variants for peer:send and host:broadcast which accepts light userdata and size

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -79,6 +79,7 @@ Released: N/A
 * Added love.sensor module.
 * Added love.sensorupdated callback.
 * Added love.joysticksensorupdated callback.
+* Added variant for enet peer:send and host:broadcast which accepts a pointer (light userdata) and a size.
 
 * Changed love.filesystem.exists to no longer be deprecated.
 * Changed the default font from Vera size 12 to Noto Sans size 13.

--- a/src/libraries/enet/enet.cpp
+++ b/src/libraries/enet/enet.cpp
@@ -234,12 +234,21 @@ static void push_event(lua_State *l, ENetEvent *event) {
 
 /**
  * Read a packet off the stack as a string
- * idx is position of string
+ * idx is position of string or lightuserdata
  */
 static ENetPacket *read_packet(lua_State *l, int idx, enet_uint8 *channel_id) {
 	size_t size;
 	int argc = lua_gettop(l);
-	const void *data = luaL_checklstring(l, idx, &size);
+	const void* data;
+
+	if (lua_islightuserdata(l, idx)) {
+		data = lua_touserdata(l, idx);
+		size = (size_t) luaL_checknumber(l, idx + 1);
+		idx++;
+	}
+	else {
+		data = luaL_checklstring(l, idx, &size);
+	}
 	ENetPacket *packet;
 
 	enet_uint32 flags = ENET_PACKET_FLAG_RELIABLE;


### PR DESCRIPTION
Was #1791 but rewritten to exclude the include of `love::data` by using light userdata and a size

This adds the following variants for `peer:send` and `host:broadcast` while preserving the previous function arguments
`peer:send(light userdata pointer, number size, [number channel, [string flag]])`
`host:broadcast(light userdata pointer, number size, [number channel, [string flag]])`

Working example
```lua
-- client
local enet = require("enet")
local host = enet.host_create()
local server = host:connect("localhost:10001", 64, 0)
host:service(100)

-- populate byteData
local byteData = love.data.newByteData(5)
local ffi = require("ffi")
local ptr = ffi.cast("void*", byteData:getFFIPointer())
ffi.copy(ptr, "hello")

server:send(byteData:getPointer(), byteData:getSize(), 11, "reliable") -- send data

love.update = function()
  host:service(10)
end
```
```lua
-- server
local enet = require("enet")
local host = enet.host_create("*:10001", 64, 0)

local text, channel
love.update = function()
  local event = host:service(10)
  if event and event.type == "receive" then
    text = event.data
    channel = event.channel
  end
end

love.draw = function()
-- prints 'hello' once client joins and the channel it was sent on
  love.graphics.print(tostring(text).."\nChannel: "..tostring(channel))
end
```