### PR TITLE
Fixed issue #1925

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -139,6 +139,7 @@ Released: N/A
 
 * Fixed BezierCurve:render adding collinear points in some situations.
 * Fixed sound Decoders to cause a Lua error instead of hard-crashing when memory for the decoding buffer can't be allocated.
+* Fixed enum misspelling for thousandsseparator from thsousandsseparator for both keyboard and scancode enums.
 
 LOVE 11.5 [Mysterious Mysteries]
 --------------------------------

--- a/src/modules/keyboard/Keyboard.cpp
+++ b/src/modules/keyboard/Keyboard.cpp
@@ -221,7 +221,7 @@ StringMap<Keyboard::Key, Keyboard::KEY_MAX_ENUM>::Entry Keyboard::keyEntries[] =
 	{"oper", Keyboard::KEY_OPER},
 	{"clearagain", Keyboard::KEY_CLEARAGAIN},
 
-	{"thsousandsseparator", Keyboard::KEY_THOUSANDSSEPARATOR},
+	{"thousandsseparator", Keyboard::KEY_THOUSANDSSEPARATOR},
 	{"decimalseparator", Keyboard::KEY_DECIMALSEPARATOR},
 	{"currencyunit", Keyboard::KEY_CURRENCYUNIT},
 	{"currencysubunit", Keyboard::KEY_CURRENCYSUBUNIT},
@@ -442,7 +442,7 @@ StringMap<Keyboard::Scancode, Keyboard::SCANCODE_MAX_ENUM>::Entry Keyboard::scan
 
 	{"kp00", SCANCODE_KP_00},
 	{"kp000", SCANCODE_KP_000},
-	{"thsousandsseparator", SCANCODE_THOUSANDSSEPARATOR},
+	{"thousandsseparator", SCANCODE_THOUSANDSSEPARATOR},
 	{"decimalseparator", SCANCODE_DECIMALSEPARATOR},
 	{"currencyunit", SCANCODE_CURRENCYUNIT},
 	{"currencysubunit", SCANCODE_CURRENCYSUBUNIT},


### PR DESCRIPTION
Fixed misspelling for both keyboard and scancode enums for thousandsseparator from thsousandsseparator (issue #1925)

```lua
love.update = function()
  love.keyboard.isScancodeDown("thousandsseparator") -- would previously error; not a valid enum
end
```