### PR TITLE
Reap zombie processes left behind by openURL

### DIFF
--- a/src/modules/system/System.cpp
+++ b/src/modules/system/System.cpp
@@ -53,6 +53,29 @@
 #endif
 #endif
 
+#if defined(LOVE_LINUX)
+#include <unordered_set>
+
+static std::unordered_set<pid_t>& getSpawnedPids()
+{
+	static std::unordered_set<pid_t> spawnedPids;
+	return spawnedPids;
+}
+
+static void sigchldHandler(int signo, siginfo_t* info, void* /*context*/)
+{
+	// We need to be selective when reaping child processes, because simply calling
+	// `waitpid` on every child process that terminated will break any other calls
+	// to `waitpid`.
+	// Particularly `os.execute` (internally: `system`) will always return -1, because
+	// their call to `waitpid` returned `ECHILD`, since we already reaped the process.
+	// This was reported in #1047 and fixed with a similar approach in 30ff7d4 and f7d226d
+	// and then later removed in a4a62f3.
+	if (getSpawnedPids().erase(info->si_pid) > 0)
+		::waitpid(info->si_pid, nullptr, 0);
+}
+#endif
+
 namespace love
 {
 namespace system
@@ -60,6 +83,13 @@ namespace system
 
 System::System()
 {
+#if defined(LOVE_LINUX)
+	struct sigaction sa;
+	sa.sa_sigaction = sigchldHandler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = SA_RESTART | SA_SIGINFO;
+	sigaction(SIGCHLD, &sa, nullptr);
+#endif
 }
 
 std::string System::getOS() const
@@ -130,6 +160,8 @@ bool System::openURL(const std::string &url) const
 		return false;
 	}
 #endif
+
+	getSpawnedPids().insert(pid);
 
 	// Check if xdg-open already completed (or failed.)
 	int status = 0;


### PR DESCRIPTION
This was attempted to be fixed in f7d226d but sadly broke os.execute (#1047), so it was later removed in a4a62f3.
This is a very similar fix, but we make sure to only waitpid for processes that we are supposed to reap.

Without this fix an example program like this would leave behind zombie processes:
```lua
function love.load()
    love.system.openURL("https://theshoemaker.de")
    love.system.openURL("https://google.de")
end
```
```bash
$ ps --ppid (pidof love)
    PID TTY          TIME CMD
 133235 pts/2    00:00:00 xdg-open <defunct>
 133236 pts/2    00:00:00 xdg-open <defunct>
```
With the fix, those zombie processes are gone.
I also made sure that this doesn't also break os.execute. This example program:
```lua
function love.load()
    love.system.openURL("https://theshoemaker.de")
    love.system.openURL("https://google.de")
    print(os.execute("false"))
    print(os.execute("true"))
end
```
prints
```
256
0
```

I am not sure if my comment in the code is too verbose, but considering it took me a while to figure out what went on there in the past, I thought it would be better to write too much than too little. Let me know if anything needs changing.

Also I am not sure if that fix is even worth it. It's not very clean to leave them behind and they might be annoying, but the typical löve program does not open enough URLs for this to become a real problem.