### PR TITLE
Alternative Fusing Method using Windows Resource

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,8 @@ set(LOVE_SRC_COMMON
 	#src/common/Vector.cpp # Vector.cpp is empty.
 	src/common/Vector.h
 	src/common/version.h
+	src/common/win32.cpp
+	src/common/win32.h
 )
 
 if (APPLE)

--- a/src/common/win32.cpp
+++ b/src/common/win32.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2006-2023 LOVE Development Team
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ **/
+
+#include "win32.h"
+
+#ifdef LOVE_WINDOWS
+
+#include <windows.h>
+
+namespace love
+{
+namespace windows
+{
+
+const std::tuple<void*, size_t> getGameInResource()
+{
+	static void *archiveData = nullptr;
+	static size_t archiveSize = 0;
+	static bool tested = false;
+
+	if (!tested)
+	{
+		HRSRC resource = FindResourceA(nullptr, "GAME", RT_RCDATA);
+		tested = true;
+
+		if (resource != nullptr)
+		{
+			HGLOBAL resourceData = LoadResource(nullptr, resource);
+
+			if (resourceData != nullptr)
+			{
+				archiveSize = SizeofResource(nullptr, resource);
+				archiveData = LockResource(resourceData);
+			}
+		}
+	}
+
+	return std::make_tuple(archiveData, archiveSize);
+}
+
+} // windows
+} // love
+
+#endif // LOVE_WINDOWS

--- a/src/common/win32.h
+++ b/src/common/win32.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2006-2023 LOVE Development Team
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ **/
+
+#ifndef LOVE_WIN32_H
+#define LOVE_WIN32_H
+
+#include "config.h"
+
+#ifdef LOVE_WINDOWS
+
+#include <tuple>
+
+namespace love
+{
+namespace windows
+{
+
+const std::tuple<void*, size_t> getGameInResource();
+
+} // windows
+} // love
+
+#endif // LOVE_WINDOWS
+#endif // LOVE_WIN32_H

--- a/src/modules/filesystem/physfs/Filesystem.cpp
+++ b/src/modules/filesystem/physfs/Filesystem.cpp
@@ -37,6 +37,7 @@
 #ifdef LOVE_WINDOWS
 #	include <windows.h>
 #	include <direct.h>
+#	include "common/win32.h"
 #else
 #	include <sys/param.h>
 #	include <unistd.h>
@@ -283,6 +284,21 @@ bool Filesystem::setSource(const char *source)
 		}
 	}
 #else
+#ifdef LOVE_WINDOWS
+	auto gameInResource = love::windows::getGameInResource();
+	if (std::get<0>(gameInResource) != nullptr)
+	{
+		if (PHYSFS_mountMemory(std::get<0>(gameInResource), std::get<1>(gameInResource), nullptr, new_search_path.c_str(), nullptr, 1))
+		{
+			// Save the game source.
+			game_source = new_search_path;
+			return true;
+		}
+	}
+
+	// Fallthrough, test for traditional fusing.
+#endif
+
 	// Add the directory.
 	if (!PHYSFS_mount(new_search_path.c_str(), nullptr, 1))
 		return false;


### PR DESCRIPTION
This PR must be discussed thoroughly before being merged, since this PR is meant to compete with #1930. Criticism and suggestions are welcome.

-----

This PR adds "alternative" fusing method in Windows that's compatible when the executable is signed. Traditional fusing (`copy /b love.exe+game.love game.exe`) does not work when the resulting executable (`game.exe`) is signed, resulting in no-game screen after signing.

To use this alternative fusing method, use a resource editor to `love.exe` or `lovec.exe` and add a new resource with type of `RCDATA` (Binary Resources) called "`GAME`". The resource contents should be an archive supported by PhysFS containing all your game just like an ordinary .love file has.