### PR TITLE
vk: maintenance

### DIFF
--- a/src/modules/graphics/vulkan/Graphics.cpp
+++ b/src/modules/graphics/vulkan/Graphics.cpp
@@ -1173,7 +1173,6 @@ void Graphics::beginFrame()
 
 	if (frameCounter >= USAGES_POLL_INTERVAL)
 	{
-		vkDeviceWaitIdle(device);
 		cleanupUnusedObjects();
 		frameCounter = 0;
 	}

--- a/src/modules/graphics/vulkan/Graphics.cpp
+++ b/src/modules/graphics/vulkan/Graphics.cpp
@@ -514,7 +514,7 @@ void Graphics::present(void *screenshotCallbackdata)
 
 void Graphics::setViewportSize(int width, int height, int pixelwidth, int pixelheight)
 {
-	if (swapChain != VK_NULL_HANDLE && (pixelWidth != this->pixelWidth || pixelHeight != this->pixelHeight || width != this->width || height != this->height))
+	if (swapChain != VK_NULL_HANDLE && (pixelwidth != this->pixelWidth || pixelheight != this->pixelHeight || width != this->width || height != this->height))
 		requestSwapchainRecreation();
 
 	this->width = width;
@@ -1850,20 +1850,34 @@ void Graphics::createSwapChain()
 
 VkSurfaceFormatKHR Graphics::chooseSwapSurfaceFormat(const std::vector<VkSurfaceFormatKHR> &availableFormats)
 {
+	std::vector<VkFormat> formatOrder;
+
 	// TODO: turn off GammaCorrect if a sRGB format can't be found?
+	// TODO: does every platform have these formats?
 	if (isGammaCorrect())
 	{
-		for (const auto &availableFormat : availableFormats)
-			// fixme: what if this format and colorspace is not available?
-			if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB && availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
-				return availableFormat;
+		formatOrder = {
+				VK_FORMAT_B8G8R8A8_SRGB,
+				VK_FORMAT_R8G8B8A8_SRGB,
+		};
+	}
+	else
+	{
+		formatOrder = {
+				VK_FORMAT_B8G8R8A8_UNORM,
+				VK_FORMAT_R8G8B8A8_SNORM,
+		};
 	}
 
-	for (const auto &availableFormat : availableFormats)
-		// fixme: what if this format and colorspace is not available?
-		if (availableFormat.format == VK_FORMAT_B8G8R8A8_UNORM && availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
-			return availableFormat;
-
+	for (const auto format : formatOrder)
+	{
+		for (const auto &availableFormat : availableFormats)
+		{
+			if (availableFormat.format == format && availableFormat.colorSpace == VK_COLORSPACE_SRGB_NONLINEAR_KHR)
+				return availableFormat;
+		}
+	}
+	
 	return availableFormats[0];
 }
 

--- a/src/modules/graphics/vulkan/Graphics.cpp
+++ b/src/modules/graphics/vulkan/Graphics.cpp
@@ -559,8 +559,6 @@ bool Graphics::setMode(void *context, int width, int height, int pixelwidth, int
 
 	beginFrame();
 
-	uint8 whiteColor[] = { 255, 255, 255, 255 };
-
 	if (batchedDrawState.vb[0] == nullptr)
 	{
 		// Initial sizes that should be good enough for most cases. It will
@@ -570,9 +568,19 @@ bool Graphics::setMode(void *context, int width, int height, int pixelwidth, int
 		batchedDrawState.indexBuffer = new StreamBuffer(this, BUFFERUSAGE_INDEX, sizeof(uint16) * LOVE_UINT16_MAX);
 	}
 
+	// sometimes the VertexTexCoord is not set, so we manually adjust it to (0, 0)
+	if (defaultConstantTexCoord == nullptr)
+	{
+		float zeroTexCoord[2] = { 0.0f, 0.0f };
+		Buffer::DataDeclaration format("ConstantTexCoord", DATAFORMAT_FLOAT_VEC2);
+		Buffer::Settings settings(BUFFERUSAGEFLAG_VERTEX, BUFFERDATAUSAGE_STATIC);
+		defaultConstantTexCoord = newBuffer(settings, { format }, zeroTexCoord, sizeof(zeroTexCoord), 1);
+	}
+
 	// sometimes the VertexColor is not set, so we manually adjust it to white color
 	if (defaultConstantColor == nullptr)
 	{
+		uint8 whiteColor[] = { 255, 255, 255, 255 };
 		Buffer::DataDeclaration format("ConstantColor", DATAFORMAT_UNORM8_VEC4);
 		Buffer::Settings settings(BUFFERUSAGEFLAG_VERTEX, BUFFERDATAUSAGE_STATIC);
 		defaultConstantColor = newBuffer(settings, { format }, whiteColor, sizeof(whiteColor), 1);
@@ -2217,11 +2225,6 @@ VkRenderPass Graphics::getRenderPass(RenderPassConfiguration &configuration)
 	return renderPass;
 }
 
-bool Graphics::usesConstantVertexColor(const VertexAttributes &vertexAttributes)
-{
-	return !!(vertexAttributes.enableBits & (1u << ATTRIB_COLOR));
-}
-
 void Graphics::createVulkanVertexFormat(
 	VertexAttributes vertexAttributes,
 	std::vector<VkVertexInputBindingDescription> &bindingDescriptions,
@@ -2233,6 +2236,7 @@ void Graphics::createVulkanVertexFormat(
 	auto allBits = enableBits;
 
 	bool usesColor = false;
+	bool usesTexCoord = false;
 
 	uint8_t highestBufferBinding = 0;
 
@@ -2242,6 +2246,8 @@ void Graphics::createVulkanVertexFormat(
 		uint32 bit = 1u << i;
 		if (enableBits & bit)
 		{
+			if (i == ATTRIB_TEXCOORD)
+				usesTexCoord = true;
 			if (i == ATTRIB_COLOR)
 				usesColor = true;
 
@@ -2276,11 +2282,31 @@ void Graphics::createVulkanVertexFormat(
 		allBits >>= 1;
 	}
 
+	if (!usesTexCoord)
+	{
+		// FIXME: is there a case where gaps happen between buffer bindings?
+		// then this doesn't work. We might need to enable null buffers again.
+		const auto constantTexCoordBufferBinding = ++highestBufferBinding;
+
+		VkVertexInputBindingDescription bindingDescription{};
+		bindingDescription.binding = constantTexCoordBufferBinding;
+		bindingDescription.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+		bindingDescription.stride = 0;	// no stride, will always read the same coord multiple times.
+		bindingDescriptions.push_back(bindingDescription);
+
+		VkVertexInputAttributeDescription attributeDescription{};
+		attributeDescription.binding = constantTexCoordBufferBinding;
+		attributeDescription.location = ATTRIB_TEXCOORD;
+		attributeDescription.offset = 0;
+		attributeDescription.format = VK_FORMAT_R32G32_SFLOAT;
+		attributeDescriptions.push_back(attributeDescription);
+	}
+
 	if (!usesColor)
 	{
 		// FIXME: is there a case where gaps happen between buffer bindings?
 		// then this doesn't work. We might need to enable null buffers again.
-		const auto constantColorBufferBinding = highestBufferBinding + 1;
+		const auto constantColorBufferBinding = ++highestBufferBinding;
 
 		VkVertexInputBindingDescription bindingDescription{};
 		bindingDescription.binding = constantColorBufferBinding;
@@ -2340,7 +2366,13 @@ void Graphics::prepareDraw(const VertexAttributes &attributes, const BufferBindi
 		}
 	}
 
-	if (!usesConstantVertexColor(attributes))
+	if (!(attributes.enableBits & (1u << ATTRIB_TEXCOORD)))
+	{
+		bufferVector.push_back((VkBuffer)defaultConstantTexCoord->getHandle());
+		offsets.push_back((VkDeviceSize)0);
+	}
+
+	if (!(attributes.enableBits & (1u << ATTRIB_COLOR)))
 	{
 		bufferVector.push_back((VkBuffer)defaultConstantColor->getHandle());
 		offsets.push_back((VkDeviceSize)0);

--- a/src/modules/graphics/vulkan/Graphics.cpp
+++ b/src/modules/graphics/vulkan/Graphics.cpp
@@ -1647,10 +1647,11 @@ void Graphics::createLogicalDevice()
 
 	VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extendedDynamicStateFeatures{};
 	extendedDynamicStateFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT;
-	extendedDynamicStateFeatures.extendedDynamicState = Vulkan::getBool(optionalDeviceExtensions.extendedDynamicState);
+	extendedDynamicStateFeatures.extendedDynamicState = VK_TRUE;
 	extendedDynamicStateFeatures.pNext = nullptr;
 
-	createInfo.pNext = &extendedDynamicStateFeatures;
+	if (optionalDeviceExtensions.extendedDynamicState)
+		createInfo.pNext = &extendedDynamicStateFeatures;
 
 	if (vkCreateDevice(physicalDevice, &createInfo, nullptr, &device) != VK_SUCCESS)
 		throw love::Exception("failed to create logical device");

--- a/src/modules/graphics/vulkan/Graphics.cpp
+++ b/src/modules/graphics/vulkan/Graphics.cpp
@@ -1263,11 +1263,6 @@ const VkDeviceSize Graphics::getMinUniformBufferOffsetAlignment() const
 	return minUniformBufferOffsetAlignment;
 }
 
-graphics::Texture *Graphics::getDefaultTexture() const
-{
-	return defaultTexture;
-}
-
 VkCommandBuffer Graphics::getCommandBufferForDataTransfer()
 {
 	if (renderPassState.active)

--- a/src/modules/graphics/vulkan/Graphics.cpp
+++ b/src/modules/graphics/vulkan/Graphics.cpp
@@ -2410,8 +2410,6 @@ void Graphics::setDefaultRenderPass()
 
 void Graphics::setRenderPass(const RenderTargets &rts, int pixelw, int pixelh, bool hasSRGBtexture)
 {
-	auto currentCommandBuffer = commandBuffers.at(currentFrame);
-
 	// fixme: hasSRGBtexture
 	RenderPassConfiguration renderPassConfiguration{};
 	for (const auto &color : rts.colors)

--- a/src/modules/graphics/vulkan/Graphics.h
+++ b/src/modules/graphics/vulkan/Graphics.h
@@ -366,7 +366,6 @@ private:
 	void startRecordingGraphicsCommands();
 	void endRecordingGraphicsCommands();
 	void ensureGraphicsPipelineConfiguration(GraphicsPipelineConfiguration &configuration);
-	bool usesConstantVertexColor(const VertexAttributes &attribs);
 	void createVulkanVertexFormat(
 		VertexAttributes vertexAttributes, 
 		std::vector<VkVertexInputBindingDescription> &bindingDescriptions, 
@@ -435,6 +434,7 @@ private:
 	VmaAllocator vmaAllocator = VK_NULL_HANDLE;
 	StrongRef<love::graphics::Texture> defaultTexture;
 	StrongRef<love::graphics::Buffer> defaultConstantColor;
+	StrongRef<love::graphics::Buffer> defaultConstantTexCoord;
 	// functions that need to be called to cleanup objects that were needed for rendering a frame.
 	// We need a vector for each frame in flight.
 	std::vector<std::vector<std::function<void()>>> cleanUpFunctions;

--- a/src/modules/graphics/vulkan/Graphics.h
+++ b/src/modules/graphics/vulkan/Graphics.h
@@ -262,13 +262,12 @@ public:
 	Graphics();
 	~Graphics();
 
-	const char *getName() const override;
-	const VkDevice getDevice() const;
-	const VmaAllocator getVmaAllocator() const;
-
 	// implementation for virtual functions
+	const char *getName() const override;
 	love::graphics::Texture *newTexture(const love::graphics::Texture::Settings &settings, const love::graphics::Texture::Slices *data) override;
 	love::graphics::Buffer *newBuffer(const love::graphics::Buffer::Settings &settings, const std::vector<love::graphics::Buffer::DataDeclaration>& format, const void *data, size_t size, size_t arraylength) override;
+	graphics::GraphicsReadback *newReadbackInternal(ReadbackMethod method, love::graphics::Buffer *buffer, size_t offset, size_t size, data::ByteData *dest, size_t destoffset) override;
+	graphics::GraphicsReadback *newReadbackInternal(ReadbackMethod method, love::graphics::Texture *texture, int slice, int mipmap, const Rect &rect, image::ImageData *dest, int destx, int desty) override;
 	void clear(OptionalColorD color, OptionalInt stencil, OptionalDouble depth) override;
 	void clear(const std::vector<OptionalColorD> &colors, OptionalInt stencil, OptionalDouble depth) override;
 	Matrix4 computeDeviceProjection(const Matrix4 &projection, bool rendertotexture) const override;
@@ -299,17 +298,15 @@ public:
 	void draw(const DrawIndexedCommand &cmd) override;
 	void drawQuads(int start, int count, const VertexAttributes &attributes, const BufferBindings &buffers, graphics::Texture *texture) override;
 
-	graphics::GraphicsReadback *newReadbackInternal(ReadbackMethod method, love::graphics::Buffer *buffer, size_t offset, size_t size, data::ByteData *dest, size_t destoffset) override;
-	graphics::GraphicsReadback *newReadbackInternal(ReadbackMethod method, love::graphics::Texture *texture, int slice, int mipmap, const Rect &rect, image::ImageData *dest, int destx, int desty) override;
-
 	// internal functions.
 
+	const VkDevice getDevice() const;
+	const VmaAllocator getVmaAllocator() const;
 	VkCommandBuffer getCommandBufferForDataTransfer();
 	void queueCleanUp(std::function<void()> cleanUp);
 	void addReadbackCallback(std::function<void()> callback);
 	void submitGpuCommands(bool present, void *screenshotCallbackData = nullptr);
 	const VkDeviceSize getMinUniformBufferOffsetAlignment() const;
-	graphics::Texture *getDefaultTexture() const;
 	VkSampler getCachedSampler(const SamplerState &sampler);
 	void setComputeShader(Shader *computeShader);
 	graphics::Shader::BuiltinUniformData getCurrentBuiltinUniformData();

--- a/src/modules/graphics/vulkan/Shader.cpp
+++ b/src/modules/graphics/vulkan/Shader.cpp
@@ -1099,7 +1099,7 @@ void Shader::setMainTex(graphics::Texture *texture)
 	}
 }
 
-VkDescriptorPool Shader::createDescriptorPool()
+void Shader::createDescriptorPool()
 {
 	VkDescriptorPoolCreateInfo createInfo{};
 	createInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;

--- a/src/modules/graphics/vulkan/Shader.cpp
+++ b/src/modules/graphics/vulkan/Shader.cpp
@@ -232,7 +232,7 @@ static EShLanguage getGlslShaderType(ShaderStageType stage)
 	}
 }
 
-static bool usesLocalUniformData(const graphics::Shader::UniformInfo* info)
+static bool usesLocalUniformData(const graphics::Shader::UniformInfo *info)
 {
 	return info->baseType == graphics::Shader::UNIFORM_BOOL ||
 		info->baseType == graphics::Shader::UNIFORM_FLOAT ||
@@ -304,7 +304,7 @@ void Shader::unloadVolatile()
 	}
 
 	vgfx->queueCleanUp([shaderModules = std::move(shaderModules), device = device, descriptorSetLayout = descriptorSetLayout, pipelineLayout = pipelineLayout, descriptorPools = descriptorPools, computePipeline = computePipeline](){
-		for (const auto& pools : descriptorPools)
+		for (const auto &pools : descriptorPools)
 		{
 			for (const auto pool : pools)
 				vkDestroyDescriptorPool(device, pool, nullptr);
@@ -370,10 +370,10 @@ void Shader::cmdPushDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBind
 {
 	VkDescriptorSet currentDescriptorSet = allocateDescriptorSet();
 
-	std::vector<VkDescriptorBufferInfo> bufferInfos{};
+	std::vector<VkDescriptorBufferInfo> bufferInfos;
 	bufferInfos.reserve(numBuffers);
 
-	std::vector<VkDescriptorImageInfo> imageInfos{};
+	std::vector<VkDescriptorImageInfo> imageInfos;
 	imageInfos.reserve(numTextures);
 
 	std::vector<VkBufferView> bufferViews;
@@ -775,7 +775,7 @@ void Shader::compileShaders()
 		{
 			if (resource.name == "gl_DefaultUniformBlock")
 			{
-				const auto& type = comp.get_type(resource.base_type_id);
+				const auto &type = comp.get_type(resource.base_type_id);
 				size_t defaultUniformBlockSize = comp.get_declared_struct_size(type);
 
 				localUniformStagingData.resize(defaultUniformBlockSize);
@@ -1068,9 +1068,9 @@ void Shader::createDescriptorPoolSizes()
 	{
 		VkDescriptorPoolSize size{};
 		auto type = Vulkan::getDescriptorType(entry.second.baseType);
-		if (type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) {
+		if (type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
 			continue;
-		}
+
 		size.type = type;
 		size.descriptorCount = 1;
 		descriptorPoolSizes.push_back(size);

--- a/src/modules/graphics/vulkan/Shader.cpp
+++ b/src/modules/graphics/vulkan/Shader.cpp
@@ -903,11 +903,9 @@ void Shader::compileShaders()
 			}
 			else
 			{
-				auto tex = vgfx->getDefaultTexture();
 				for (int i = 0; i < info.count; i++)
 				{
-					info.textures[i] = tex;
-					tex->retain();
+					info.textures[i] = nullptr;
 				}
 			}
 
@@ -1113,7 +1111,8 @@ void Shader::setVideoTextures(graphics::Texture *ytexture, graphics::Texture *cb
 		if (builtinUniformInfo[builtIns[i]] != nullptr)
 		{
 			textures[i]->retain();
-			builtinUniformInfo[builtIns[i]]->textures[0]->release();
+			if (builtinUniformInfo[builtIns[i]]->textures[0])
+				builtinUniformInfo[builtIns[i]]->textures[0]->release();
 			builtinUniformInfo[builtIns[i]]->textures[0] = textures[i];
 		}
 	}
@@ -1129,7 +1128,8 @@ void Shader::setMainTex(graphics::Texture *texture)
 	if (builtinUniformInfo[BUILTIN_TEXTURE_MAIN] != nullptr)
 	{
 		texture->retain();
-		builtinUniformInfo[BUILTIN_TEXTURE_MAIN]->textures[0]->release();
+		if (builtinUniformInfo[BUILTIN_TEXTURE_MAIN]->textures[0]) 
+			builtinUniformInfo[BUILTIN_TEXTURE_MAIN]->textures[0]->release();
 		builtinUniformInfo[BUILTIN_TEXTURE_MAIN]->textures[0] = texture;
 	}
 }

--- a/src/modules/graphics/vulkan/Shader.cpp
+++ b/src/modules/graphics/vulkan/Shader.cpp
@@ -178,24 +178,17 @@ public:
 
 
 private:
-	uint32_t getFreeBinding() {
+	uint32_t getFreeBinding()
+	{
 		for (uint32_t i = 0;; i++)
 		{
-			bool free = true;
-			for (const auto &entry : bindingMappings)
-			{
-				if (entry.second == i)
-				{
-					free = false;
-					break;
-				}
-			}
-			if (free)
+			if (isFreeBinding(i))
 				return i;
 		}
 	}
 
-	bool isFreeBinding(uint32_t binding) {
+	bool isFreeBinding(uint32_t binding)
+	{
 		for (const auto &entry : bindingMappings)
 		{
 			if (entry.second == binding)
@@ -218,8 +211,8 @@ static VkShaderStageFlagBits getStageBit(ShaderStageType type)
 		return VK_SHADER_STAGE_FRAGMENT_BIT;
 	case SHADERSTAGE_COMPUTE:
 		return VK_SHADER_STAGE_COMPUTE_BIT;
-    default:
-	    throw love::Exception("invalid type");
+	default:
+		throw love::Exception("invalid type");
 	}
 }
 

--- a/src/modules/graphics/vulkan/Shader.h
+++ b/src/modules/graphics/vulkan/Shader.h
@@ -97,12 +97,8 @@ private:
 	void createPipelineLayout();
 	void createDescriptorPoolSizes();
 	void createStreamBuffers();
-	void buildLocalUniforms(
-		spirv_cross::Compiler &comp, 
-		const spirv_cross::SPIRType &type, 
-		size_t baseoff, 
-		const std::string &basename);
-
+	void buildLocalUniforms(spirv_cross::Compiler &comp, const spirv_cross::SPIRType &type, size_t baseoff, const std::string &basename);
+	VkDescriptorPool createDescriptorPool();
 	VkDescriptorSet allocateDescriptorSet();
 
 	VkDeviceSize uniformBufferSizeAligned;
@@ -117,7 +113,6 @@ private:
 	// we keep a vector of stream buffers that gets dynamically increased if more memory is needed
 	std::vector<StreamBuffer*> streamBuffers;
 	std::vector<VkDescriptorPool> descriptorPools;
-	std::queue<VkDescriptorSet> freeDescriptorSets;
 	std::vector<std::vector<VkDescriptorSet>> descriptorSetsVector;
 
 	std::vector<VkPipelineShaderStageCreateInfo> shaderStages;

--- a/src/modules/graphics/vulkan/Shader.h
+++ b/src/modules/graphics/vulkan/Shader.h
@@ -102,7 +102,6 @@ private:
 		const spirv_cross::SPIRType &type, 
 		size_t baseoff, 
 		const std::string &basename);
-	void updateUniform(const UniformInfo *info, int count, bool internal);
 
 	VkDescriptorSet allocateDescriptorSet();
 
@@ -120,8 +119,6 @@ private:
 	std::vector<VkDescriptorPool> descriptorPools;
 	std::queue<VkDescriptorSet> freeDescriptorSets;
 	std::vector<std::vector<VkDescriptorSet>> descriptorSetsVector;
-
-	std::set<uint32_t> updatedUniforms;
 
 	std::vector<VkPipelineShaderStageCreateInfo> shaderStages;
 	std::vector<VkShaderModule> shaderModules;

--- a/src/modules/graphics/vulkan/Shader.h
+++ b/src/modules/graphics/vulkan/Shader.h
@@ -98,7 +98,7 @@ private:
 	void createDescriptorPoolSizes();
 	void createStreamBuffers();
 	void buildLocalUniforms(spirv_cross::Compiler &comp, const spirv_cross::SPIRType &type, size_t baseoff, const std::string &basename);
-	VkDescriptorPool createDescriptorPool();
+	void createDescriptorPool();
 	VkDescriptorSet allocateDescriptorSet();
 
 	VkDeviceSize uniformBufferSizeAligned;

--- a/src/modules/graphics/vulkan/Shader.h
+++ b/src/modules/graphics/vulkan/Shader.h
@@ -70,7 +70,7 @@ public:
 
 	void attach() override;
 
-	ptrdiff_t getHandle() const { return 0; }
+	ptrdiff_t getHandle() const override { return 0; }
 
 	std::string getWarnings() const override { return ""; }
 

--- a/src/modules/graphics/vulkan/Shader.h
+++ b/src/modules/graphics/vulkan/Shader.h
@@ -105,6 +105,10 @@ private:
 
 	VkPipeline computePipeline;
 
+	uint32_t numTextures;
+	uint32_t numBuffers;
+	uint32_t numBufferViews;
+
 	VkDescriptorSetLayout descriptorSetLayout;
 	VkPipelineLayout pipelineLayout;
 	std::vector<VkDescriptorPoolSize> descriptorPoolSizes;
@@ -133,8 +137,6 @@ private:
 	OptionalInt builtinUniformDataOffset;
 
 	std::unordered_map<std::string, int> attributes;
-
-	VkDescriptorSet currentDescriptorSet;
 
 	uint32_t currentFrame;
 	uint32_t currentUsedUniformStreamBuffersCount;

--- a/src/modules/graphics/vulkan/Shader.h
+++ b/src/modules/graphics/vulkan/Shader.h
@@ -116,8 +116,7 @@ private:
 	// we don't know how much memory we need per frame for the uniform buffer descriptors
 	// we keep a vector of stream buffers that gets dynamically increased if more memory is needed
 	std::vector<StreamBuffer*> streamBuffers;
-	std::vector<VkDescriptorPool> descriptorPools;
-	std::vector<std::vector<VkDescriptorSet>> descriptorSetsVector;
+	std::vector<std::vector<VkDescriptorPool>> descriptorPools;
 
 	std::vector<VkPipelineShaderStageCreateInfo> shaderStages;
 	std::vector<VkShaderModule> shaderModules;
@@ -140,7 +139,7 @@ private:
 
 	uint32_t currentFrame;
 	uint32_t currentUsedUniformStreamBuffersCount;
-	uint32_t currentUsedDescriptorSetsCount;
+	uint32_t currentDescriptorPool;
 };
 
 }


### PR DESCRIPTION
Just a few things I have found and improved:
- Running löve under RenderDoc doesn't crash anymore
- Running löve with an android emulator uses right gamma correction
- Running g3d example works correctly (although y axis flipped)
- Handling of descriptor pools / sets in Shader.h/.cpp has been simplified
- Vulkan::cmdTransitionImageLayout has been changed to be more maintainable
