### PR TITLE
MinGW: Adopt utf-16 encoded love.rc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1777,6 +1777,12 @@ if(MSVC OR MINGW)
 		extra/windows/love.rc
 		extra/windows/love.ico
 	)
+
+	if(MINGW)
+		# UTF-16 flags passed to windres. windres invokes gcc as preprocessor
+		# -> gcc outputs utf8, so windres must read-in codepage 65001 (utf8)
+		set(CMAKE_RC_FLAGS ${CMAKE_RC_FLAGS} "-c 65001 --preprocessor-arg=-finput-charset=UTF-16LE")
+	endif()
 endif()
 
 add_library(${LOVE_LIB_NAME} SHARED ${LOVE_LIB_SRC} ${LOVE_RC})


### PR DESCRIPTION
This PR adopts utf-16 compatibility (`love.rc`) when building for MinGW.

Apologies for changing the encoding in #1985, I missed the notice in the header of love.rc and looking at the CI output, windows-1252 seemed to produce sane results on win32 and win64.