### PR TITLE
Fix deprecated love.graphics.stencil function resetting stencilMode

### DIFF
--- a/src/modules/graphics/wrap_Graphics.lua
+++ b/src/modules/graphics/wrap_Graphics.lua
@@ -64,7 +64,7 @@ function graphics.stencil(func, action, value, keepvalues)
 	local action2, mode2, value2, readmask2, writemask2 = graphics.getStencilMode()
 	local mr, mg, mb, ma = graphics.getColorMask()
 
-	graphics.setStencilMode(action, "always", value)s
+	graphics.setStencilMode(action, "always", value)
 	graphics.setColorMask(false)
 
 	local success, err = pcall(func)

--- a/src/modules/graphics/wrap_Graphics.lua
+++ b/src/modules/graphics/wrap_Graphics.lua
@@ -61,15 +61,16 @@ function graphics.stencil(func, action, value, keepvalues)
 
 	if value == nil then value = 1 end
 
-	graphics.setStencilMode(action, "always", value)
-
+	local action2, mode2, value2, readmask2, writemask2 = graphics.getStencilMode()
 	local mr, mg, mb, ma = graphics.getColorMask()
+
+	graphics.setStencilMode(action, "always", value)s
 	graphics.setColorMask(false)
 
 	local success, err = pcall(func)
 
+	graphics.setStencilMode(action2, mode2, value2, readmask2, writemask2)
 	graphics.setColorMask(mr, mg, mb, ma)
-	graphics.setStencilMode()
 
 	if not success then
 		error(err, 2)


### PR DESCRIPTION
Quite self-explanatory
Games from previous versions using deprecated stencil functions will most likely not working as intended

```lua
love.graphics.stencil(stencil, "replace", 1, false)
love.graphics.setStencilTest("greater", 0)
```
Example above vice versa would work the same in previous love2d version games but since currently stencil function resets the properties it wouldnt work the same

This pr fixes it