### PR TITLE
Emit love.visible(true) on SDL_WINDOWEVENT_EXPOSED

### DIFF
--- a/src/modules/event/sdl/Event.cpp
+++ b/src/modules/event/sdl/Event.cpp
@@ -603,7 +603,8 @@ Message *Event::convertWindowEvent(const SDL_Event &e)
 		break;
 	case SDL_WINDOWEVENT_SHOWN:
 	case SDL_WINDOWEVENT_HIDDEN:
-		vargs.emplace_back(e.window.event == SDL_WINDOWEVENT_SHOWN);
+	case SDL_WINDOWEVENT_EXPOSED:
+		vargs.emplace_back(e.window.event != SDL_WINDOWEVENT_HIDDEN);
 		msg = new Message("visible", vargs);
 		break;
 	case SDL_WINDOWEVENT_RESIZED:


### PR DESCRIPTION
I'm using the i3 window manager, and SDL is firing the `SDL_WINDOWEVENT_EXPOSED` when I switch from one workspace to the workspace Love is on. The SDL wiki [says](https://wiki.libsdl.org/SDL2/SDL_WindowEventID) `SDL_WINDOWEVENT_EXPOSED` means the "window has been exposed and should be redrawn". I figured this fits in well enough to `love.visible` rather than needing its own callback.