### PR TITLE
Add More Tests For love.sensor.

### DIFF
--- a/testing/tests/sensor.lua
+++ b/testing/tests/sensor.lua
@@ -4,6 +4,51 @@
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+------------------------------------HELPERS-------------------------------------
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+local function testIsEnabled(test, sensorType)
+  love.sensor.setEnabled(sensorType, true)
+  test:assertTrue(love.sensor.isEnabled(sensorType), 'check ' .. sensorType .. ' enabled')
+  love.sensor.setEnabled(sensorType, false)
+  test:assertFalse(love.sensor.isEnabled(sensorType), 'check ' .. sensorType .. ' disabled')
+end
+
+
+local function testGetName(test, sensorType)
+  love.sensor.setEnabled(sensorType, true)
+  local ok, name = pcall(love.sensor.getName, sensorType)
+  test:assertTrue(ok, 'check sensor.getName("' .. sensorType .. '") success')
+  test:assertEquals(type(name), 'string', 'check sensor.getName("' .. sensorType .. '") return value type')
+
+  love.sensor.setEnabled(sensorType, false)
+  ok, name = pcall(love.sensor.getName, sensorType)
+  test:assertFalse(ok, 'check sensor.getName("' .. sensorType .. '") errors when disabled')
+
+  love.sensor.setEnabled(sensorType, false)
+  ok, x, y, z = pcall(love.sensor.getData, sensorType)
+  test:assertFalse(ok, 'check sensor.getData("' .. sensorType .. '") errors when disabled')
+end
+
+
+local function testGetData(test, sensorType)
+  love.sensor.setEnabled(sensorType, true)
+  local ok, x, y, z = pcall(love.sensor.getData, sensorType)
+  test:assertTrue(ok, 'check sensor.getData("' .. sensorType .. '") success')
+  if ok then
+    test:assertNotNil(x)
+    test:assertNotNil(y)
+    test:assertNotNil(z)
+  end
+
+  love.sensor.setEnabled(sensorType, false)
+  ok, x, y, z = pcall(love.sensor.getData, sensorType)
+  test:assertFalse(ok, 'check sensor.getData("' .. sensorType .. '") errors when disabled')
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 ------------------------------------METHODS-------------------------------------
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -16,4 +61,46 @@ love.test.sensor.hasSensor = function(test)
   local gyroscope = love.sensor.hasSensor('gyroscope')
   test:assertNotNil(accelerometer)
   test:assertNotNil(gyroscope)
+end
+
+
+-- love.sensor.isEnabled and love.sensor.setEnabled
+love.test.sensor.isEnabled = function(test)
+  local accelerometer = love.sensor.hasSensor('accelerometer')
+  local gyroscope = love.sensor.hasSensor('gyroscope')
+
+  if accelerometer or gyroscope then
+    if accelerometer then testIsEnabled(test, 'accelerometer') end
+    if gyroscope then testIsEnabled(test, 'gyroscope') end
+  else
+    test:skipTest('neither accelerometer nor gyroscope are supported in this system')
+  end
+end
+
+
+-- love.sensor.getName
+love.test.sensor.getName = function(test)
+  local accelerometer = love.sensor.hasSensor('accelerometer')
+  local gyroscope = love.sensor.hasSensor('gyroscope')
+
+  if accelerometer or gyroscope then
+    if accelerometer then testGetName(test, 'accelerometer') end
+    if gyroscope then testGetName(test, 'gyroscope') end
+  else
+    test:skipTest('neither accelerometer nor gyroscope are supported in this system')
+  end
+end
+
+
+-- love.sensor.getData
+love.test.sensor.getData = function(test)
+  local accelerometer = love.sensor.hasSensor('accelerometer')
+  local gyroscope = love.sensor.hasSensor('gyroscope')
+
+  if accelerometer or gyroscope then
+    if accelerometer then testGetData(test, 'accelerometer') end
+    if gyroscope then testGetData(test, 'gyroscope') end
+  else
+    test:skipTest('neither accelerometer nor gyroscope are supported in this system')
+  end
 end

--- a/testing/tests/sensor.lua
+++ b/testing/tests/sensor.lua
@@ -25,10 +25,6 @@ local function testGetName(test, sensorType)
   love.sensor.setEnabled(sensorType, false)
   ok, name = pcall(love.sensor.getName, sensorType)
   test:assertFalse(ok, 'check sensor.getName("' .. sensorType .. '") errors when disabled')
-
-  love.sensor.setEnabled(sensorType, false)
-  ok, x, y, z = pcall(love.sensor.getData, sensorType)
-  test:assertFalse(ok, 'check sensor.getData("' .. sensorType .. '") errors when disabled')
 end
 
 


### PR DESCRIPTION
This will test more `love.sensor` functions if hardware accelerometer or gyroscope is available (such as in iOS, Android, or in laptops with such sensors). Note that the tests will be skipped if no accelerometer and gyroscope is available.

The tests passed in my laptop which have both sensors. I didn't write tests for `love.sensor.setEnabled` as `love.sensor.isEnabled` also performs `setEnabled` test.

```
love.conf
--modules "sensor"

love.sensor.testmodule.start
  love.sensor.getData()                     ==> PASS - 0.026s (10/10)
  love.sensor.getName()                     ==> PASS - 0.015s (6/6)
  love.sensor.hasSensor()                   ==> PASS - 0.017s (2/2)
  love.sensor.isEnabled()                   ==> PASS - 0.016s (4/4)
love.sensor.testmodule.end
4 PASSED || 0 FAILED || 0 SKIPPED || 0.074s

FINISHED - 0.074s

4 PASSED || 0 FAILED || 0 SKIPPED
```