### PR TITLE
Make Graphics constructor explicit

### DIFF
--- a/src/modules/graphics/Graphics.h
+++ b/src/modules/graphics/Graphics.h
@@ -451,7 +451,7 @@ public:
 		}
 	};
 
-	Graphics(const char *name);
+	explicit Graphics(const char *name);
 	virtual ~Graphics();
 
 	virtual Texture *newTexture(const Texture::Settings &settings, const Texture::Slices *data = nullptr) = 0;


### PR DESCRIPTION
This prevents unexpected implicit constructions of Graphics objects from C strings, since the constructor has C string as its single input parameter.