### PR TITLE
Add support for lua 5.4 to-be-closed variables

### DIFF
--- a/src/common/runtime.cpp
+++ b/src/common/runtime.cpp
@@ -547,6 +547,10 @@ int luax_register_type(lua_State *L, love::Type *type, ...)
 	lua_pushcfunction(L, w__release);
 	lua_setfield(L, -2, "release");
 
+	// Add __close for lua 5.4 (just calls release)
+	lua_pushcfunction(L, w__release);
+	lua_setfield(L, -2, "__close");
+
 	va_list fs;
 	va_start(fs, type);
 	for (const luaL_Reg *f = va_arg(fs, const luaL_Reg *); f; f = va_arg(fs, const luaL_Reg *))


### PR DESCRIPTION
Closes #1946

Since love already handles double free-like cases for `release` using `Proxy`, this was as simple as calling `release`. Or technically, registering `__close` as an alias for `release`.

To test this I added some extra patches:
```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index ce94ff61..fac9d552 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ Please see https://github.com/love2d/megasource
                set(LOVE_LUA_LIBRARY ${LUAJIT_LIBRARY})
                set(LOVE_LUA_INCLUDE_DIR ${LUAJIT_INCLUDE_DIR})
        else()
-               find_package(Lua51 REQUIRED)
+               find_package(Lua REQUIRED)
                set(LOVE_LUA_LIBRARY ${LUA_LIBRARY})
                set(LOVE_LUA_INCLUDE_DIR ${LUA_INCLUDE_DIR})
        endif()
diff --git a/src/common/runtime.h b/src/common/runtime.h
index 747c38e8..820bd4b9 100644
--- a/src/common/runtime.h
+++ b/src/common/runtime.h
@@ -36,6 +36,11 @@ extern "C" {
        #include <lauxlib.h>
 }
 
+#if LUA_VERSION_NUM >= 504
+#define luaL_checkint luaL_checkinteger
+#define luaL_optint luaL_optinteger
+#endif
+
 // C++
 #include <exception>
 #include <algorithm>
```

And in my case a few extra prints for the demo. The output I got running this directly from lua 5.4 was:
```
Lua 5.4.6  Copyright (C) 1994-2023 Lua.org, PUC-Rio
> package.preload.love = package.loadlib("./build/Debug/liblove-12.0.so", "luaopen_love")
> love = require "love"
> require "love.math"
table: 0x5584d2f30b50	:preload:
> do local rng <close> = love.math.newRandomGenerator(); print(rng:random()) end
0.68980386685727
Calling __close
Destroying RandomGenerator
> do local rng <close> = love.math.newRandomGenerator(); print(rng:random()); rng:release() end
0.68980386685727
Calling release
Destroying RandomGenerator
Calling __close
> do local rng = love.math.newRandomGenerator(); print(rng:random()) end
0.68980386685727
> collectgarbage()
Destroying RandomGenerator
0
```

Hopefully that demonstrates that `<close>` works as intended, and it can be mixed with `release` without issue.