### PR TITLE
Remove duplicate entry in changes.txt

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -82,7 +82,6 @@ Released: N/A
 * Added love.joysticksensorupdated callback.
 * Added variant for enet peer:send and host:broadcast which accepts a pointer (light userdata) and a size.
 
-* Changed love.filesystem.exists to no longer be deprecated.
 * Changed the default font from Vera size 12 to Noto Sans size 13.
 * Changed TrueType and OpenType font handling to have improved kerning and character combining support.
 * Changed the Texture class and implementation to no longer have separate Canvas and Image subclasses.


### PR DESCRIPTION
The same entry existed on two lines:

https://github.com/love2d/love/blob/2aa4e4b3ea1522961f51d44a9f01f33b1db43030/changes.txt#L85

https://github.com/love2d/love/blob/2aa4e4b3ea1522961f51d44a9f01f33b1db43030/changes.txt#L100

so I removed one.
