### PR TITLE
Add -fobjc-arc for love_3p_luahttps on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1606,6 +1606,7 @@ if (APPLE)
 		src/libraries/luahttps/src/apple/NSURLClient.mm
 		src/libraries/luahttps/src/apple/NSURLClient.h
 	)
+	target_compile_options(love_3p_luahttps PRIVATE -fobjc-arc)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
Add `-fobjc-arc` when building for love_3p_luahttps on macOS.

Fixes error: "ARC is off"

I'm aware of the warning that "CMake is not an officially supported build system for love on Apple platforms"; this is a small step toward improving it.

This PR is for the main branch. The problem also affects the 12.0-development branch but that branch has not been updated in three months and other changes in CMakeLists.txt in the main branch mean this patch would have to be changed to apply to the 12.0-development branch.

The 11.x branch is not affected because the luahttps module was not used in that branch.