### PR TITLE
Make alext.h optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,8 @@ Please see https://github.com/love2d/megasource
 	find_package(OpenAL REQUIRED)
 	target_include_directories(lovedep::OpenAL INTERFACE ${OPENAL_INCLUDE_DIR})
 	target_link_libraries(lovedep::OpenAL INTERFACE ${OPENAL_LIBRARY})
+  include(CheckIncludeFileCXX)
+  check_include_file_cxx("alext.h" HAVE_OPENAL_ALEXT_H)
 
 	find_package(ModPlug REQUIRED)
 	target_include_directories(lovedep::Modplug INTERFACE ${MODPLUG_INCLUDE_DIR})

--- a/src/modules/audio/openal/Audio.h
+++ b/src/modules/audio/openal/Audio.h
@@ -52,7 +52,9 @@
 #else
 #include <alc.h>
 #include <al.h>
+#if defined(HAVE_OPENAL_ALEXT_H)
 #include <alext.h>
+#endif
 #endif
 
 namespace love

--- a/src/modules/audio/openal/Effect.h
+++ b/src/modules/audio/openal/Effect.h
@@ -36,7 +36,9 @@
 #else
 #include <alc.h>
 #include <al.h>
+#if defined(HAVE_OPENAL_ALEXT_H)
 #include <alext.h>
+#endif
 #endif
 
 #include <vector>

--- a/src/modules/audio/openal/Filter.h
+++ b/src/modules/audio/openal/Filter.h
@@ -36,7 +36,9 @@
 #else
 #include <alc.h>
 #include <al.h>
+#if defined(HAVE_OPENAL_ALEXT_H)
 #include <alext.h>
+#endif
 #endif
 
 #include <vector>

--- a/src/modules/audio/openal/Pool.h
+++ b/src/modules/audio/openal/Pool.h
@@ -48,7 +48,9 @@
 #else
 #include <alc.h>
 #include <al.h>
+#if defined(HAVE_OPENAL_ALEXT_H)
 #include <alext.h>
+#endif
 #endif
 
 namespace love


### PR DESCRIPTION
macOS doesn't seem to have these files but love compiles fine if we just don't include them. Otherwise it fails as the header cannot be found.