### PR TITLE
Made love.data.newDataView size arg optional

### DIFF
--- a/src/modules/data/wrap_DataModule.cpp
+++ b/src/modules/data/wrap_DataModule.cpp
@@ -57,7 +57,7 @@ int w_newDataView(lua_State *L)
 	Data *data = luax_checkdata(L, 1);
 
 	lua_Integer offset = luaL_checkinteger(L, 2);
-	lua_Integer size = luaL_checkinteger(L, 3);
+	lua_Integer size = luaL_optinteger(L, 3, data->getSize() - offset);
 
 	if (offset < 0 || size < 0)
 		return luaL_error(L, "DataView offset and size must not be negative.");


### PR DESCRIPTION
I got annoyed that I had to keep calculating the size lua side when making a new dataview. So, this change makes the 3rd arg [size], optional and is calculated as `love.data.newByteData` calculates the default size when calling `love.data.newByteData(someData)`  [this line](https://github.com/love2d/love/blob/main/src/modules/data/wrap_DataModule.cpp#L88)

I made this change on github directly; and so I haven't tested the change. I'll add a comment once I've tested the build to ensure it works as expected.

Example usage:
```lua
local data = love.data.newByteData(200)
local offset = 100

-- Change:
local dataview = love.data.newDataView(data, offset)
-- Previously:
local dataview = love.data.newDataView(data, offset, data:getSize() - offset)
```