### PR TITLE
Improve `"justify"` text alignment

### DIFF
--- a/src/modules/font/GenericShaper.cpp
+++ b/src/modules/font/GenericShaper.cpp
@@ -49,6 +49,7 @@ void GenericShaper::computeGlyphPositions(const ColoredCodepoints &codepoints, R
 
 	// Spacing counter and newline handling.
 	Vector2 curpos = offset;
+	float spacingremainder = 0;
 
 	float maxwidth = 0;
 	uint32 prevglyph = 0;
@@ -125,7 +126,11 @@ void GenericShaper::computeGlyphPositions(const ColoredCodepoints &codepoints, R
 
 		// Account for extra spacing given to space characters.
 		if (g == ' ' && extraspacing != 0.0f)
-			curpos.x += extraspacing;
+		{
+			spacingremainder += fmod(extraspacing, 1);
+			curpos.x += floorf(extraspacing) + floorf(spacingremainder);
+			spacingremainder = fmod(spacingremainder, 1);
+		}
 
 		prevglyph = g;
 	}

--- a/src/modules/font/freetype/HarfbuzzShaper.cpp
+++ b/src/modules/font/freetype/HarfbuzzShaper.cpp
@@ -208,6 +208,7 @@ void HarfbuzzShaper::computeGlyphPositions(const ColoredCodepoints &codepoints, 
 
 	offset.y += getBaseline();
 	Vector2 curpos = offset;
+	float spacingremainder = 0;
 
 	int colorindex = 0;
 	int ncolors = (int)codepoints.colors.size();
@@ -312,7 +313,11 @@ void HarfbuzzShaper::computeGlyphPositions(const ColoredCodepoints &codepoints, 
 
 			// Account for extra spacing given to space characters.
 			if (clustercodepoint == ' ' && extraspacing != 0.0f)
-				curpos.x += extraspacing;
+			{
+				spacingremainder += fmod(extraspacing, 1);
+				curpos.x += floorf(extraspacing) + floorf(spacingremainder);
+				spacingremainder = fmod(spacingremainder, 1);
+			}
 		}
 	}
 

--- a/src/modules/graphics/Font.cpp
+++ b/src/modules/graphics/Font.cpp
@@ -508,7 +508,7 @@ std::vector<Font::DrawCommand> Font::generateVerticesFormatted(const love::font:
 				auto end = start + range.getSize();
 				float numspaces = std::count(start, end, ' ');
 				if (width < wrap && numspaces >= 1)
-					extraspacing = floorf((wrap - width) / numspaces);
+					extraspacing = (wrap - width) / (numspaces - 1);
 				else
 					extraspacing = 0.0f;
 				break;

--- a/src/modules/graphics/Font.cpp
+++ b/src/modules/graphics/Font.cpp
@@ -507,8 +507,12 @@ std::vector<Font::DrawCommand> Font::generateVerticesFormatted(const love::font:
 				auto start = text.cps.begin() + range.getOffset();
 				auto end = start + range.getSize();
 				float numspaces = std::count(start, end, ' ');
+
+				if (text.cps[range.last] == ' ')
+					--numspaces;
+
 				if (width < wrap && numspaces >= 1)
-					extraspacing = (wrap - width) / (numspaces - 1);
+					extraspacing = (wrap - width) / numspaces;
 				else
 					extraspacing = 0.0f;
 				break;


### PR DESCRIPTION
The `"justify"` align mode now looks more like proper justified text - the right edges of lines are flush with the given wrap width.

Before:

https://github.com/user-attachments/assets/1e53dca5-9276-4f87-a73d-10029ca307c4

After:

https://github.com/user-attachments/assets/5fca5614-5df9-4b70-aecd-db5043a41fab

