### PR TITLE
added hidehomeindicator for iOS

### DIFF
--- a/src/modules/love/boot.lua
+++ b/src/modules/love/boot.lua
@@ -180,6 +180,7 @@ function love.init()
 			resizable = false,
 			centered = true,
 			usedpiscale = true,
+			hidehomeindicator = "0",
 		},
 		graphics = {
 			gammacorrect = false,
@@ -401,6 +402,7 @@ function love.init()
 			display = c.window.display, -- deprecated
 			highdpi = c.window.highdpi, -- deprecated
 			usedpiscale = c.window.usedpiscale,
+			hidehomeindicator = c.window.hidehomeindicator,
 			x = c.window.x,
 			y = c.window.y,
 		}), "Could not set window mode")

--- a/src/modules/window/Window.cpp
+++ b/src/modules/window/Window.cpp
@@ -73,6 +73,7 @@ STRINGMAP_CLASS_BEGIN(Window, Window::Setting, Window::SETTING_MAX_ENUM, setting
 	{"display", Window::SETTING_DISPLAY},
 	{"highdpi", Window::SETTING_HIGHDPI},
 	{"usedpiscale", Window::SETTING_USE_DPISCALE},
+	{"hidehomeindicator", Window::SETTING_HIDEHOMEINDICATOR},
 	{"refreshrate", Window::SETTING_REFRESHRATE},
 	{"x", Window::SETTING_X},
 	{"y", Window::SETTING_Y},

--- a/src/modules/window/Window.h
+++ b/src/modules/window/Window.h
@@ -75,6 +75,7 @@ public:
 		SETTING_DISPLAY, // Deprecated
 		SETTING_HIGHDPI, // Deprecated
 		SETTING_USE_DPISCALE,
+		SETTING_HIDEHOMEINDICATOR,
 		SETTING_REFRESHRATE,
 		SETTING_X,
 		SETTING_Y,
@@ -279,6 +280,7 @@ struct WindowSettings
 	bool centered = true;
 	int displayindex = 0;
 	bool usedpiscale = true;
+	char *hidehomeindicator = "0";
 	double refreshrate = 0.0;
 	bool useposition = false;
 	int x = 0;

--- a/src/modules/window/sdl/Window.cpp
+++ b/src/modules/window/sdl/Window.cpp
@@ -569,6 +569,9 @@ bool Window::setWindow(int width, int height, WindowSettings *settings)
 		}
 	}
 
+	if (f.hidehomeindicator)
+		SDL_SetHint(SDL_HINT_IOS_HIDE_HOME_INDICATOR, f.hidehomeindicator);
+
 	bool needsetmode = false;
 
 	if (renderer != windowRenderer && isOpen())
@@ -760,6 +763,8 @@ void Window::updateSettings(const WindowSettings &newsettings, bool updateGraphi
 	setHighDPIAllowed((wflags & SDL_WINDOW_HIGH_PIXEL_DENSITY) != 0);
 
 	settings.usedpiscale = newsettings.usedpiscale;
+
+	settings.hidehomeindicator = newsettings.hidehomeindicator;
 
 	// Only minimize on focus loss if the window is in exclusive-fullscreen mode
 	if (settings.fullscreen && settings.fstype == FULLSCREEN_EXCLUSIVE)

--- a/src/modules/window/wrap_Window.cpp
+++ b/src/modules/window/wrap_Window.cpp
@@ -76,6 +76,11 @@ static int readWindowSettings(lua_State *L, int idx, WindowSettings &settings)
 	settings.centered = luax_boolflag(L, idx, settingName(Window::SETTING_CENTERED), settings.centered);
 	settings.usedpiscale = luax_boolflag(L, idx, settingName(Window::SETTING_USE_DPISCALE), settings.usedpiscale);
 
+	lua_getfield(L, idx, settingName(Window::SETTING_HIDEHOMEINDICATOR));
+	if (!lua_isnoneornil(L, -1))
+		settings.hidehomeindicator = (char *) lua_tostring(L, -1);
+	lua_pop(L, 1);
+
 	lua_getfield(L, idx, settingName(Window::SETTING_DEPTH));
 	if (lua_type(L, -1) == LUA_TNUMBER)
 	{
@@ -231,6 +236,9 @@ int w_getMode(lua_State *L)
 
 	luax_pushboolean(L, settings.usedpiscale);
 	lua_setfield(L, -2, settingName(Window::SETTING_USE_DPISCALE));
+
+	lua_pushstring(L, settings.hidehomeindicator);
+	lua_setfield(L, -2, settingName(Window::SETTING_HIDEHOMEINDICATOR));
 
 	lua_pushnumber(L, settings.refreshrate);
 	lua_setfield(L, -2, settingName(Window::SETTING_REFRESHRATE));


### PR DESCRIPTION
Currently there is no way to control the way the home indicator behaves on iOS without needing to modify the Love source code. This PR aims to add such of an ability via love.conf under `window.hidehomeindicator` and uses SDL3's `SDL_HINT_IOS_HIDE_HOME_INDICATOR` hint. Feel free to let me know any additional changes you'd like to see for this PR.

Example of `window.hidehomeindicator` set to `"2"`
![Screen Recording 2024-12-31 at 1 09 27 AM-SD 480p](https://github.com/user-attachments/assets/1ec958df-67a0-49e0-9735-a9866153454e)

```lua
function love.conf(t)
    
    t.window.title = "Prismical [dev build 7-18-24]"

    t.window.minwidth = 256
    t.window.minheight = 144
    t.window.width = 256*3
    t.window.height = 144*3
    t.window.resizable = true
    t.window.highdpi = true
    t.window.hidehomeindicator = "2"
    
end
```