### PR TITLE
Replace NativeFile to use SDL IO functions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,11 +482,9 @@ add_library(love_filesystem_physfs STATIC
 	src/modules/filesystem/physfs/PhysfsIo.h
 	src/modules/filesystem/physfs/PhysfsIo.cpp
 )
-if(ANDROID)
-	target_link_libraries(love_filesystem_physfs PUBLIC
-		lovedep::SDL
-	)
-endif()
+target_link_libraries(love_filesystem_physfs PUBLIC
+	lovedep::SDL
+)
 
 add_library(love_filesystem INTERFACE)
 target_link_libraries(love_filesystem INTERFACE
@@ -1962,7 +1960,7 @@ love_group_projects(NAME "liblove" NESTED TARGETS ${LIBLOVE_DEPENDENCIES})
 love_group_projects(NAME "liblove/libraries" NESTED TARGETS ${LIBLOVE_LIBRARIES})
 love_group_projects(NAME "liblove" TARGETS liblove ${LOVE_EXTRA_DEPENDECIES})
 
-love_group_projects(NAME "lovedep" TARGETS lovedep::SDL3 lovedep::Freetype lovedep::Harfbuzz lovedep::OpenAL lovedep::Modplug lovedep::Theora lovedep::Vorbis lovedep::Ogg lovedep::Zlib lovedep::Lua)
+love_group_projects(NAME "lovedep" TARGETS lovedep::SDL lovedep::Freetype lovedep::Harfbuzz lovedep::OpenAL lovedep::Modplug lovedep::Theora lovedep::Vorbis lovedep::Ogg lovedep::Zlib lovedep::Lua)
 love_group_projects(NAME "lovedep" TARGETS lua51 alcommon al-excommon harfbuzz-subset zlib)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,9 +482,11 @@ add_library(love_filesystem_physfs STATIC
 	src/modules/filesystem/physfs/PhysfsIo.h
 	src/modules/filesystem/physfs/PhysfsIo.cpp
 )
-target_link_libraries(love_filesystem_physfs PUBLIC
-	lovedep::SDL
-)
+if(ANDROID)
+	target_link_libraries(love_filesystem_physfs PUBLIC
+		lovedep::SDL
+	)
+endif()
 
 add_library(love_filesystem INTERFACE)
 target_link_libraries(love_filesystem INTERFACE

--- a/extra/cmake/LoveMacros.cmake
+++ b/extra/cmake/LoveMacros.cmake
@@ -16,6 +16,12 @@ function(love_group_projects)
 				foreach(TARGET_LIB ${TARGET_LIBS})
 					# Is this a target? (Could also be a .lib file)
 					if (TARGET ${TARGET_LIB})
+						# Resolve aliased target
+						get_target_property(ORIGINAL_TARGET ${TARGET_LIB} ALIASED_TARGET)
+						if (ORIGINAL_TARGET)
+							set(TARGET_LIB ${ORIGINAL_TARGET})
+						endif()
+
 						# Do we want to nest per-project?
 						if (LOVE_GROUP_NESTED)
 							set_target_properties(${TARGET_LIB} PROPERTIES FOLDER "${LOVE_GROUP_NAME}/${TARGET_NAME}")

--- a/src/modules/filesystem/NativeFile.cpp
+++ b/src/modules/filesystem/NativeFile.cpp
@@ -36,6 +36,9 @@
 #include <unistd.h> // POSIX.
 #endif
 
+// SDL
+#include <SDL3/SDL_iostream.h>
+
 namespace love
 {
 namespace filesystem

--- a/src/modules/filesystem/NativeFile.cpp
+++ b/src/modules/filesystem/NativeFile.cpp
@@ -20,21 +20,9 @@
 
 // LOVE
 #include "NativeFile.h"
-#include "common/utf8.h"
 
-#ifdef LOVE_ANDROID
-#include "common/android.h"
-#endif
-
-// Assume POSIX or Visual Studio.
-#include <sys/types.h>
-#include <sys/stat.h>
-
-#ifdef LOVE_WINDOWS
-#include <wchar.h>
-#else
-#include <unistd.h> // POSIX.
-#endif
+// C
+#include <cstring>
 
 // SDL
 #include <SDL3/SDL_iostream.h>
@@ -48,8 +36,10 @@ NativeFile::NativeFile(const std::string &filename, Mode mode)
 : filename(filename)
 , file(nullptr)
 , mode(MODE_CLOSED)
+, buffer(nullptr)
 , bufferMode(BUFFER_NONE)
 , bufferSize(0)
+, bufferUsed(0)
 {
 	if (!open(mode))
 		throw love::Exception("Could not open file at path %s", filename.c_str());
@@ -59,8 +49,10 @@ NativeFile::NativeFile(const NativeFile &other)
 : filename(other.filename)
 , file(nullptr)
 , mode(MODE_CLOSED)
+, buffer(nullptr)
 , bufferMode(other.bufferMode)
 , bufferSize(other.bufferSize)
+, bufferUsed(0)
 {
 	if (!open(other.mode))
 		throw love::Exception("Could not open file at path %s", filename.c_str());
@@ -95,18 +87,31 @@ bool NativeFile::open(Mode newmode)
 
 	mode = newmode;
 
+	if (!setupBuffering(bufferMode, bufferSize))
+	{
+		SDL_CloseIO(file);
+		file = nullptr;
+		mode = MODE_CLOSED;
+		throw love::Exception("Could not open file %s: cannot setup buffering", filename.c_str());
+	}
+
 	return file != nullptr;
 }
 
 bool NativeFile::close()
 {
-	if (file == nullptr || !SDL_CloseIO(file))
+	if (file == nullptr)
 		return false;
 
+	bool success = flush();
+	success = SDL_CloseIO(file) && success;
+	// Regardless whetever SDL_CloseIO succeeded or failed, the `file`
+	// pointer is no longer valid.
 	mode = MODE_CLOSED;
 	file = nullptr;
+	setupBuffering(BUFFER_NONE, 0);
 
-	return true;
+	return success;
 }
 
 bool NativeFile::isOpen() const
@@ -116,8 +121,11 @@ bool NativeFile::isOpen() const
 
 int64 NativeFile::getSize()
 {
+	if (!file)
+		return -1;
+
 	int64 size = SDL_GetIOSize(file);
-	return std::max(size, -1LL);
+	return std::max<int64>(size, -1);
 }
 
 int64 NativeFile::read(void *dst, int64 size)
@@ -128,8 +136,12 @@ int64 NativeFile::read(void *dst, int64 size)
 	if (size < 0)
 		throw love::Exception("Invalid read size.");
 
-	size_t read = SDL_ReadIO(file, dst, (size_t) size);
+	// Are we using buffers?
+	if (buffer)
+		return bufferedRead(dst, size);
 
+	// No buffering.
+	size_t read = SDL_ReadIO(file, dst, (size_t) size);
 	return (int64) read;
 }
 
@@ -141,17 +153,60 @@ bool NativeFile::write(const void *data, int64 size)
 	if (size < 0)
 		throw love::Exception("Invalid write size.");
 
-	int64 written = SDL_WriteIO(file, data, (size_t) size);
+	if (buffer)
+	{
+		if (!bufferedWrite(data, size))
+			return false;
 
-	return written == size;
+		// There's newline? force flush
+		if (bufferMode == BUFFER_LINE && memchr(data, '\n', size) != nullptr)
+		{
+			if (!flush())
+				return false;
+		}
+	}
+	else
+		return SDL_WriteIO(file, data, (size_t) size) == (size_t) size;
+
+	return true;
 }
 
 bool NativeFile::flush()
 {
-	if (!file || (mode != MODE_WRITE && mode != MODE_APPEND))
-		throw love::Exception("File is not opened for writing.");
+	switch (mode)
+	{
+		case MODE_READ:
+		{
+			if (buffer)
+			{
+				// Seek to already consumed buffer
+				if (SDL_SeekIO(file, (size_t) (bufferUsed - bufferSize), SDL_IO_SEEK_CUR) < 0)
+					return false;
 
-	return SDL_FlushIO(file);
+				// Mark as depleted
+				bufferUsed = bufferSize;
+			}
+			
+			return true;
+		}
+		case MODE_WRITE:
+		case MODE_APPEND:
+		{
+			if (buffer && bufferUsed > 0)
+			{
+				size_t written = SDL_WriteIO(file, buffer, (size_t) bufferUsed);
+				memmove(buffer, buffer + written, (size_t) bufferSize - written);
+				bufferUsed = std::max<int64>(bufferUsed - (int64) written, 0);
+			}
+
+			return SDL_FlushIO(file);
+		}
+		default:
+			throw love::Exception("Invalid file mode.");
+	}
+
+	// Make sure compiler doesn't emit warnings.
+	return true;
 }
 
 bool NativeFile::isEOF()
@@ -164,12 +219,34 @@ int64 NativeFile::tell()
 	if (file == nullptr)
 		return -1;
 
-	return SDL_TellIO(file);
+	int64 offset = 0;
+	if (buffer)
+	{
+		switch (mode)
+		{
+			case MODE_READ:
+				// Note: We want offset be negative for reading
+				offset = bufferUsed - bufferSize;
+				break;
+			case MODE_WRITE:
+			case MODE_APPEND:
+				offset = bufferUsed;
+				break;
+		}
+	}
+
+	return SDL_TellIO(file) + offset;
 }
 
 bool NativeFile::seek(int64 pos, SeekOrigin origin)
 {
 	if (file == nullptr)
+		return false;
+
+	if (mode == MODE_APPEND)
+		// FIXME: PhysFS "append" allows the user to
+		// seek the write pointer, but it's not possible
+		// to do so with standard fopen-style modes.
 		return false;
 
 	SDL_IOWhence whence = SDL_IO_SEEK_SET;
@@ -178,18 +255,52 @@ bool NativeFile::seek(int64 pos, SeekOrigin origin)
 	else if (origin == SEEKORIGIN_END)
 		whence = SDL_IO_SEEK_END;
 
-	return SDL_SeekIO(file, pos, whence) >= 0;
+	if (mode == MODE_READ && whence == SDL_IO_SEEK_SET && buffer)
+	{
+		// Retain the buffer if it's forward.
+		// TODO: Handle SDL_IO_SEEK_CUR.
+		int64 offset = pos - tell();
+		if (offset >= 0 && (offset + bufferUsed) < bufferSize)
+		{
+			// Seek success
+			bufferUsed += offset;
+			return true;
+		}
+
+		// Note: We don't handle backward seek because the
+		// contents past `bufferUsed` is not necessarily valid.
+	}
+
+	// If the read is buffered, the flush() will ensure
+	// the read pointer is in correct place before doing seek.
+	return flush() && (SDL_SeekIO(file, pos, whence) >= 0);
 }
 
 bool NativeFile::setBuffer(BufferMode bufmode, int64 size)
 {
 	if (size < 0)
 		return false;
+	else if (sizeof(uintptr_t) == 4 && size > 0x80000000LL)
+		// Safeguards against 32-bit integer truncation?
+		return false;
 
 	if (bufmode == BUFFER_NONE)
 		size = 0;
+	else if (size == 0)
+		// This should do for now
+		size = BUFSIZ;
 
-	// FIXME: SDL doesn't have option to set buffering.
+	// If there's no file handle, we'll setup the buffering later in open()
+	if (file)
+	{
+		// Ideally we don't want to flush if user request larger buffer size
+		// but the added complexity is not worth it for now.
+		if (!flush())
+			return false;
+
+		if (!setupBuffering(bufmode, size))
+			return false;
+	}
 
 	bufferMode = bufmode;
 	bufferSize = size;
@@ -213,6 +324,75 @@ File::Mode NativeFile::getMode() const
 	return mode;
 }
 
+bool NativeFile::setupBuffering(BufferMode mode, int64 bufferSize)
+{
+	int8 *newbuf = nullptr;
+	if (mode != BUFFER_NONE)
+	{
+		newbuf = new (std::nothrow) int8[(size_t) bufferSize];
+		if (newbuf == nullptr)
+			return false;
+	}
+
+	delete[] buffer;
+	buffer = newbuf;
+	bufferUsed = this->mode == MODE_READ ? bufferSize : 0;
+	return true;
+}
+
+int64 NativeFile::bufferedRead(void *dst, int64 size)
+{
+	int8 *ptr = (int8 *) dst;
+	int64 readed = 0;
+
+	while (size > 0)
+	{
+		int64 available = bufferSize - bufferUsed;
+
+		if (available > 0)
+		{
+			// There's leftover buffers.
+			size_t copy = (size_t) std::min(size, available);
+			memcpy(ptr, buffer + (size_t) bufferUsed, copy);
+
+			ptr += copy;
+			size -= (int64) copy;
+			bufferUsed += (int64) copy;
+			readed += copy;
+		}
+		else
+		{
+			// Buffer is empty. Fill it.
+			size_t ureaded = SDL_ReadIO(file, buffer, (size_t) bufferSize);
+			bufferUsed = bufferSize - (int64) ureaded;
+
+			if (ureaded == 0)
+				break;
+
+			if (bufferUsed > 0)
+				// Shift the buffer so code above can properly index it
+				memmove(buffer + bufferUsed, buffer, ureaded);
+		}
+	}
+
+	return readed;
+}
+
+bool NativeFile::bufferedWrite(const void *data, int64 size)
+{
+	if ((size + bufferUsed) < bufferSize)
+	{
+		// Entire data fits in the buffer.
+		memcpy(buffer + bufferUsed, data, size);
+		bufferUsed += size;
+		return true;
+	}
+
+	// Could overflow. Write directly.
+	size_t writeSize = (size_t) size;
+	return flush() && (SDL_WriteIO(file, data, writeSize) == writeSize);
+}
+
 const char *NativeFile::getModeString(Mode mode)
 {
 	switch (mode)
@@ -225,9 +405,6 @@ const char *NativeFile::getModeString(Mode mode)
 	case File::MODE_WRITE:
 		return "wb";
 	case File::MODE_APPEND:
-		// Note: PhysFS "append" allows the user to
-		// seek the write pointer, but it's not possible
-		// to do so with standard fopen-style modes.
 		return "ab";
 	}
 }

--- a/src/modules/filesystem/NativeFile.cpp
+++ b/src/modules/filesystem/NativeFile.cpp
@@ -121,10 +121,16 @@ bool NativeFile::isOpen() const
 
 int64 NativeFile::getSize()
 {
+	int64 size = -1;
 	if (!file)
-		return -1;
+	{
+		open(MODE_READ);
+		size = SDL_GetIOSize(file);
+		close();
+	}
+	else
+		size = SDL_GetIOSize(file);
 
-	int64 size = SDL_GetIOSize(file);
 	return std::max<int64>(size, -1);
 }
 

--- a/src/modules/filesystem/NativeFile.cpp
+++ b/src/modules/filesystem/NativeFile.cpp
@@ -42,22 +42,22 @@ namespace filesystem
 {
 
 NativeFile::NativeFile(const std::string &filename, Mode mode)
-	: filename(filename)
-	, file(nullptr)
-	, mode(MODE_CLOSED)
-	, bufferMode(BUFFER_NONE)
-	, bufferSize(0)
+: filename(filename)
+, file(nullptr)
+, mode(MODE_CLOSED)
+, bufferMode(BUFFER_NONE)
+, bufferSize(0)
 {
 	if (!open(mode))
 		throw love::Exception("Could not open file at path %s", filename.c_str());
 }
 
 NativeFile::NativeFile(const NativeFile &other)
-	: filename(other.filename)
-	, file(nullptr)
-	, mode(MODE_CLOSED)
-	, bufferMode(other.bufferMode)
-	, bufferSize(other.bufferSize)
+: filename(other.filename)
+, file(nullptr)
+, mode(MODE_CLOSED)
+, bufferMode(other.bufferMode)
+, bufferSize(other.bufferSize)
 {
 	if (!open(other.mode))
 		throw love::Exception("Could not open file at path %s", filename.c_str());
@@ -86,49 +86,23 @@ bool NativeFile::open(Mode newmode)
 	if (file != nullptr)
 		return false;
 
-#if defined(LOVE_ANDROID)
-	// Try to handle content:// URI
-	int fd = love::android::getFDFromContentProtocol(filename.c_str());
-	if (fd != -1)
+	file = SDL_IOFromFile(filename.c_str(), getModeString(newmode));
+	if (file == nullptr)
 	{
-		if (newmode != MODE_READ)
-		{
-			::close(fd);
-			throw love::Exception("%s is read-only.", filename.c_str());
-		}
+		std::string err = SDL_GetError();
 
-		file = fdopen(fd, "rb");
+		if (err != "")
+			throw love::Exception("Could not open file %s: %s", filename.c_str(), err.c_str());
 	}
 	else
-		file = fopen(filename.c_str(), getModeString(newmode));
-#elif defined(LOVE_WINDOWS)
-	// make sure non-ASCII filenames work.
-	std::wstring modestr = to_widestr(getModeString(newmode));
-	std::wstring wfilename = to_widestr(filename);
-
-	file = _wfopen(wfilename.c_str(), modestr.c_str());
-#else
-	file = fopen(filename.c_str(), getModeString(newmode));
-#endif
-
-	if (newmode == MODE_READ && file == nullptr)
-		throw love::Exception("Could not open file %s. Does not exist.", filename.c_str());
-
-	mode = newmode;
-
-	if (file != nullptr && !setBuffer(bufferMode, bufferSize))
-	{
-		// Revert to buffer defaults if we don't successfully set the buffer.
-		bufferMode = BUFFER_NONE;
-		bufferSize = 0;
-	}
+		mode = newmode;
 
 	return file != nullptr;
 }
 
 bool NativeFile::close()
 {
-	if (file == nullptr || fclose(file) != 0)
+	if (file == nullptr || !SDL_CloseIO(file))
 		return false;
 
 	mode = MODE_CLOSED;
@@ -144,44 +118,8 @@ bool NativeFile::isOpen() const
 
 int64 NativeFile::getSize()
 {
-	int fd = file ? fileno(file) : -1;
-
-#ifdef LOVE_WINDOWS
-	
-	struct _stat64 buf;
-
-	if (fd != -1)
-	{
-		if (_fstat64(fd, &buf) != 0)
-			return -1;
-	}
-	else
-	{
-		// make sure non-ASCII filenames work.
-		std::wstring wfilename = to_widestr(filename);
-
-		if (_wstat64(wfilename.c_str(), &buf) != 0)
-			return -1;
-	}
-
-	return (int64) buf.st_size;
-
-#else
-
-	// Assume POSIX support...
-	struct stat buf;
-
-	if (fd != -1)
-	{
-		if (fstat(fd, &buf) != 0)
-			return -1;
-	}
-	else if (stat(filename.c_str(), &buf) != 0)
-		return -1;
-
-	return (int64) buf.st_size;
-
-#endif
+	int64 size = SDL_GetIOSize(file);
+	return std::max(size, -1LL);
 }
 
 int64 NativeFile::read(void *dst, int64 size)
@@ -192,7 +130,7 @@ int64 NativeFile::read(void *dst, int64 size)
 	if (size < 0)
 		throw love::Exception("Invalid read size.");
 
-	size_t read = fread(dst, 1, (size_t) size, file);
+	size_t read = SDL_ReadIO(file, dst, (size_t) size);
 
 	return (int64) read;
 }
@@ -205,7 +143,7 @@ bool NativeFile::write(const void *data, int64 size)
 	if (size < 0)
 		throw love::Exception("Invalid write size.");
 
-	int64 written = (int64) fwrite(data, 1, (size_t) size, file);
+	int64 written = SDL_WriteIO(file, data, (size_t) size);
 
 	return written == size;
 }
@@ -215,7 +153,7 @@ bool NativeFile::flush()
 	if (!file || (mode != MODE_WRITE && mode != MODE_APPEND))
 		throw love::Exception("File is not opened for writing.");
 
-	return fflush(file) == 0;
+	return SDL_FlushIO(file);
 }
 
 bool NativeFile::isEOF()
@@ -228,11 +166,7 @@ int64 NativeFile::tell()
 	if (file == nullptr)
 		return -1;
 
-#ifdef LOVE_WINDOWS
-	return (int64) _ftelli64(file);
-#else
-	return (int64) ftello(file);
-#endif
+	return SDL_TellIO(file);
 }
 
 bool NativeFile::seek(int64 pos, SeekOrigin origin)
@@ -240,18 +174,13 @@ bool NativeFile::seek(int64 pos, SeekOrigin origin)
 	if (file == nullptr)
 		return false;
 
-	int forigin = SEEK_SET;
+	SDL_IOWhence whence = SDL_IO_SEEK_SET;
 	if (origin == SEEKORIGIN_CURRENT)
-		forigin = SEEK_CUR;
+		whence = SDL_IO_SEEK_CUR;
 	else if (origin == SEEKORIGIN_END)
-		forigin = SEEK_END;
+		whence = SDL_IO_SEEK_END;
 
-	// TODO
-#ifdef LOVE_WINDOWS
-	return _fseeki64(file, pos, forigin) == 0;
-#else
-	return fseeko(file, (off_t) pos, forigin) == 0;
-#endif
+	return SDL_SeekIO(file, pos, whence) >= 0;
 }
 
 bool NativeFile::setBuffer(BufferMode bufmode, int64 size)
@@ -262,32 +191,7 @@ bool NativeFile::setBuffer(BufferMode bufmode, int64 size)
 	if (bufmode == BUFFER_NONE)
 		size = 0;
 
-	// If the file isn't open, we'll make sure the buffer values are set in
-	// NativeFile::open.
-	if (!isOpen())
-	{
-		bufferMode = bufmode;
-		bufferSize = size;
-		return true;
-	}
-
-	int vbufmode;
-	switch (bufmode)
-	{
-	case File::BUFFER_NONE:
-	default:
-		vbufmode = _IONBF;
-		break;
-	case File::BUFFER_LINE:
-		vbufmode = _IOLBF;
-		break;
-	case File::BUFFER_FULL:
-		vbufmode = _IOFBF;
-		break;
-	}
-
-	if (setvbuf(file, nullptr, vbufmode, (size_t) size) != 0)
-		return false;
+	// FIXME: SDL doesn't have option to set buffering.
 
 	bufferMode = bufmode;
 	bufferSize = size;
@@ -323,6 +227,9 @@ const char *NativeFile::getModeString(Mode mode)
 	case File::MODE_WRITE:
 		return "wb";
 	case File::MODE_APPEND:
+		// Note: PhysFS "append" allows the user to
+		// seek the write pointer, but it's not possible
+		// to do so with standard fopen-style modes.
 		return "ab";
 	}
 }

--- a/src/modules/filesystem/NativeFile.cpp
+++ b/src/modules/filesystem/NativeFile.cpp
@@ -284,6 +284,10 @@ bool NativeFile::seek(int64 pos, SeekOrigin origin)
 
 bool NativeFile::setBuffer(BufferMode bufmode, int64 size)
 {
+	// BUFSIZ in Windows is too low on 512 bytes.
+	// Make sure the default buffer size is at least 4KiB.
+	constexpr int64 DEFAULT_BUFFER_SIZE = std::max<int64>(BUFSIZ, 4096);
+
 	if (size < 0)
 		return false;
 	else if (sizeof(uintptr_t) == 4 && size > 0x80000000LL)
@@ -293,8 +297,7 @@ bool NativeFile::setBuffer(BufferMode bufmode, int64 size)
 	if (bufmode == BUFFER_NONE)
 		size = 0;
 	else if (size == 0)
-		// This should do for now
-		size = BUFSIZ;
+		size = DEFAULT_BUFFER_SIZE;
 
 	// If there's no file handle, we'll setup the buffering later in open()
 	if (file)

--- a/src/modules/filesystem/NativeFile.cpp
+++ b/src/modules/filesystem/NativeFile.cpp
@@ -91,14 +91,9 @@ bool NativeFile::open(Mode newmode)
 
 	file = SDL_IOFromFile(filename.c_str(), getModeString(newmode));
 	if (file == nullptr)
-	{
-		std::string err = SDL_GetError();
+		throw love::Exception("Could not open file %s: %s", filename.c_str(), SDL_GetError());
 
-		if (err != "")
-			throw love::Exception("Could not open file %s: %s", filename.c_str(), err.c_str());
-	}
-	else
-		mode = newmode;
+	mode = newmode;
 
 	return file != nullptr;
 }

--- a/src/modules/filesystem/NativeFile.h
+++ b/src/modules/filesystem/NativeFile.h
@@ -25,8 +25,7 @@
 // C
 #include <cstdio>
 
-// SDL
-#include <SDL3/SDL_iostream.h>
+typedef struct SDL_IOStream SDL_IOStream;
 
 namespace love
 {

--- a/src/modules/filesystem/NativeFile.h
+++ b/src/modules/filesystem/NativeFile.h
@@ -25,6 +25,9 @@
 // C
 #include <cstdio>
 
+// SDL
+#include <SDL3/SDL_iostream.h>
+
 namespace love
 {
 namespace filesystem
@@ -69,7 +72,7 @@ private:
 
 	std::string filename;
 
-	FILE *file;
+	SDL_IOStream *file;
 
 	Mode mode;
 

--- a/src/modules/filesystem/NativeFile.h
+++ b/src/modules/filesystem/NativeFile.h
@@ -66,6 +66,9 @@ public:
 private:
 
 	NativeFile(const NativeFile &other);
+	bool setupBuffering(BufferMode mode, int64 bufferSize);
+	int64 bufferedRead(void* dst, int64 size);
+	bool bufferedWrite(const void* data, int64 size);
 
 	static const char *getModeString(Mode mode);
 
@@ -75,8 +78,10 @@ private:
 
 	Mode mode;
 
+	int8 *buffer;
 	BufferMode bufferMode;
 	int64 bufferSize;
+	int64 bufferUsed;
 
 }; // NativeFile
 


### PR DESCRIPTION
This removes any platform-specific code from `NativeFile` and rely on SDL3 IO functions diretly.

One issue I found with this is that SDL3 doesn't expose any function to set the IO buffering mode. This is why this change goes into a PR to discuss how should the buffering function behaves.