### PR TITLE
Fix error: 'uint32_t' has not been declared in musl system

### DIFF
--- a/src/libraries/glslang/SPIRV/SpvBuilder.h
+++ b/src/libraries/glslang/SPIRV/SpvBuilder.h
@@ -61,6 +61,7 @@ namespace spv {
 #include <set>
 #include <sstream>
 #include <stack>
+#include <cstdint>
 #include <unordered_map>
 #include <map>
 


### PR DESCRIPTION
This fix the error that made impossible the compile of love2d in any musl system