### PR TITLE
Fixed delay in changing window icon on boot

### DIFF
--- a/src/modules/love/boot.lua
+++ b/src/modules/love/boot.lua
@@ -383,6 +383,11 @@ function love.init()
 
 	-- Setup window here.
 	if c.window and c.modules.window then
+		if c.window.icon then
+			assert(love.image, "If an icon is set in love.conf, love.image must be loaded.")
+			love.window.setIcon(love.image.newImageData(c.window.icon))
+		end
+
 		love.window.setTitle(c.window.title or c.title)
 		assert(love.window.setMode(c.window.width, c.window.height,
 		{
@@ -404,10 +409,6 @@ function love.init()
 			x = c.window.x,
 			y = c.window.y,
 		}), "Could not set window mode")
-		if c.window.icon then
-			assert(love.image, "If an icon is set in love.conf, love.image must be loaded.")
-			love.window.setIcon(love.image.newImageData(c.window.icon))
-		end
 	end
 
 	-- The first couple event pumps on some systems (e.g. macOS) can take a


### PR DESCRIPTION
Changing the icon to a custom one (with t.window.icon in conf.lua) results in the icon changing with a delay:
![delayed](https://github.com/user-attachments/assets/4e94425d-31b9-486c-b47d-9fad224db802)

It is necessary to change the order of window setup in boot.lua: first change the icon, and then open the window:
![fixed](https://github.com/user-attachments/assets/e7a55dee-21f9-41ad-85ab-bd5988474d9f)
