### PR TITLE
physfs: Do not throw an exception if the filesystem is already initialized.

### DIFF
--- a/src/modules/filesystem/physfs/Filesystem.cpp
+++ b/src/modules/filesystem/physfs/Filesystem.cpp
@@ -158,6 +158,12 @@ void Filesystem::init(const char *arg0)
 
 	if (!PHYSFS_init(arg0))
 		throw love::Exception("Failed to initialize filesystem: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+	if (!PHYSFS_init(arg0)) {
+		PHYSFS_ErrorCode err = PHYSFS_getLastErrorCode();
+		if (err == PHYSFS_ERR_IS_INITIALIZED)
+			return;
+		throw love::Exception("Failed to initialize filesystem: %s", PHYSFS_getErrorByCode(err));
+	}
 
 	// Enable symlinks by default.
 	setSymlinksEnabled(true);


### PR DESCRIPTION
On my very old Android phone, when I hit Back and switch to another app, then back to the Love game, it throws this exception. Ignoring this error (PHYSFS_ERR_IS_INITIALIZED) allows me to switch back and forth no problem.