### PR TITLE
Update cmake minimum version to 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
 	message(FATAL_ERROR "Prevented in-tree build.")
 endif()
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 project(love)
 


### PR DESCRIPTION
Updated CMake minimum from 3.16 to 3.19 to address problems found by @noahwagner04 in issue #2184