### PR TITLE
Remove deprecation from PHYSFS_getUserDir function

### DIFF
--- a/src/libraries/physfs/physfs.h
+++ b/src/libraries/physfs/physfs.h
@@ -803,8 +803,6 @@ PHYSFS_DECL const char *PHYSFS_getBaseDir(void);
  * \fn const char *PHYSFS_getUserDir(void)
  * \brief Get the path where user's home directory resides.
  *
- * \deprecated As of PhysicsFS 2.1, you probably want PHYSFS_getPrefDir().
- *
  * Helper function.
  *
  * Get the "user dir". This is meant to be a suggestion of where a specific
@@ -819,7 +817,7 @@ PHYSFS_DECL const char *PHYSFS_getBaseDir(void);
  * \sa PHYSFS_getBaseDir
  * \sa PHYSFS_getPrefDir
  */
-PHYSFS_DECL const char *PHYSFS_getUserDir(void) PHYSFS_DEPRECATED;
+PHYSFS_DECL const char *PHYSFS_getUserDir(void);
 
 
 /**


### PR DESCRIPTION
`PHYSFS_getUserDir()` was deprecated for a long time, and given a deprecation warning:

```
love/src/modules/filesystem/physfs/Filesystem.cpp: In member function ‘virtual std::string love::filesystem::physfs::Filesystem::getFullCommonPath(love::filesystem::Filesystem::CommonPath)’:
love/src/modules/filesystem/physfs/Filesystem.cpp:720:62: warning: ‘const char* PHYSFS_getUserDir()’ is deprecated [-Wdeprecated-declarations]
  720 |                 fullPaths[path] = normalize(PHYSFS_getUserDir());
      |                                             ~~~~~~~~~~~~~~~~~^~
In file included from love/src/modules/filesystem/physfs/File.h:29,
                 from love/src/modules/filesystem/physfs/Filesystem.cpp:29:
love/src/libraries/physfs/physfs.h:820:25: note: declared here
  820 | PHYSFS_DECL const char *PHYSFS_getUserDir(void) PHYSFS_DEPRECATED;
      |                         ^~~~~~~~~~~~~~~~~
```

The warning about the deprecated function comes up only on Linux and Android (reported: https://github.com/love2d/love-android/issues/113 and https://github.com/love2d/love-android/issues/146). It's unlikely that this function is going to be removed in physfs 3.x, and even if it is removed from the next release, LÖVE is using modified source of the library and can keep a copy of this function.

I think it's safe to just disable the deprecation warning.