### PR TITLE
Add love.system.getMemorySize

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -81,6 +81,7 @@ Released: N/A
 * Added love.sensorupdated callback.
 * Added love.joysticksensorupdated callback.
 * Added variant for enet peer:send and host:broadcast which accepts a pointer (light userdata) and a size.
+* Added love.system.getMemorySize.
 
 * Changed the default font from Vera size 12 to Noto Sans size 13.
 * Changed TrueType and OpenType font handling to have improved kerning and character combining support.

--- a/src/modules/system/System.h
+++ b/src/modules/system/System.h
@@ -64,6 +64,11 @@ public:
 	virtual int getProcessorCount() const = 0;
 
 	/**
+	 * Gets the amount of RAM configured in the system in MiB.
+	 **/
+	virtual int getMemorySize() const = 0;
+
+	/**
 	 * Replaces the contents of the system's text clipboard with a string.
 	 * @param text The clipboard text to set.
 	 **/

--- a/src/modules/system/sdl/System.cpp
+++ b/src/modules/system/sdl/System.cpp
@@ -45,6 +45,11 @@ int System::getProcessorCount() const
 	return SDL_GetNumLogicalCPUCores();
 }
 
+int System::getMemorySize() const
+{
+	return SDL_GetSystemRAM();
+}
+
 bool System::isWindowOpen() const
 {
 	auto window = Module::getInstance<window::Window>(M_WINDOW);

--- a/src/modules/system/sdl/System.h
+++ b/src/modules/system/sdl/System.h
@@ -43,6 +43,7 @@ public:
 	virtual ~System() {}
 
 	int getProcessorCount() const override;
+	int getMemorySize() const override;
 
 	void setClipboardText(const std::string &text) const override;
 	std::string getClipboardText() const override;

--- a/src/modules/system/wrap_System.cpp
+++ b/src/modules/system/wrap_System.cpp
@@ -41,6 +41,12 @@ int w_getProcessorCount(lua_State *L)
 	return 1;
 }
 
+int w_getMemorySize(lua_State *L)
+{
+	lua_pushinteger(L, instance()->getMemorySize());
+	return 1;
+}
+
 int w_setClipboardText(lua_State *L)
 {
 	const char *text = luaL_checkstring(L, 1);
@@ -121,6 +127,7 @@ static const luaL_Reg functions[] =
 {
 	{ "getOS", w_getOS },
 	{ "getProcessorCount", w_getProcessorCount },
+	{ "getMemorySize", w_getMemorySize },
 	{ "setClipboardText", w_setClipboardText },
 	{ "getClipboardText", w_getClipboardText },
 	{ "getPowerInfo", w_getPowerInfo },

--- a/testing/tests/system.lua
+++ b/testing/tests/system.lua
@@ -59,6 +59,12 @@ love.test.system.getProcessorCount = function(test)
 end
 
 
+-- love.system.getMemorySize
+love.test.system.getMemorySize = function(test)
+  test:assertNotNil(love.system.getMemorySize())
+end
+
+
 -- love.system.hasBackgroundMusic
 love.test.system.hasBackgroundMusic = function(test)
   test:assertNotNil(love.system.hasBackgroundMusic())


### PR DESCRIPTION
Wraps SDL's [`GetSystemRAM`](https://wiki.libsdl.org/SDL3/SDL_GetSystemRAM) which is available since SDL 3.2.0 according to the docs.