### PR TITLE
Expose more battery and power connection state

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -29,6 +29,8 @@ Released: N/A
 * Added Joystick:hasSensor.
 * Added Joystick:isSensorEnabled and Joystick:setSensorEnabled.
 * Added Joystick:getSensorData.
+* Added Joystick:getDeviceBatteryPercent and Joystick:getDevicePowerState, these expose how charged batteries in a controller are and if they're charging
+* Added Joystick:getConnectionState which indicates if a joystick is connected wired or wireless
 * Added new Gamepad API buttons: "misc1", "paddle1", "paddle2", "paddle3", "paddle4". and "touchpad".
 * Added World:getFixturesInArea().
 * Added support for saving .exr image files via ImageData:encode.

--- a/src/modules/joystick/Joystick.cpp
+++ b/src/modules/joystick/Joystick.cpp
@@ -135,5 +135,25 @@ STRINGMAP_CLASS_BEGIN(Joystick, Joystick::InputType, Joystick::INPUT_TYPE_MAX_EN
 }
 STRINGMAP_CLASS_END(Joystick, Joystick::InputType, Joystick::INPUT_TYPE_MAX_ENUM, inputType)
 
+STRINGMAP_CLASS_BEGIN(Joystick, Joystick::PowerState, Joystick::POWERSTATE_MAX_ENUM, powerState)
+{
+	{ "error",        Joystick::POWERSTATE_ERROR        },
+	{ "unknown",      Joystick::POWERSTATE_UNKNOWN      },
+	{ "onbattery",    Joystick::POWERSTATE_ON_BATTERY   },
+	{ "nobattery",    Joystick::POWERSTATE_NO_BATTERY   },
+	{ "charging",     Joystick::POWERSTATE_CHARGING     },
+	{ "charged",      Joystick::POWERSTATE_CHARGED      },
+}
+STRINGMAP_CLASS_END(Joystick, Joystick::PowerState, Joystick::POWERSTATE_MAX_ENUM, powerState)
+
+STRINGMAP_CLASS_BEGIN(Joystick, Joystick::ConnectionState, Joystick::CONNECTION_MAX_ENUM, connectionState)
+{
+	{ "error",       Joystick::CONNECTION_INVALID },
+	{ "unknown",     Joystick::CONNECTION_UNKNOWN },
+	{ "wired",       Joystick::CONNECTION_WIRED },
+	{ "wireless",    Joystick::CONNECTION_WIRELESS },
+}
+STRINGMAP_CLASS_END(Joystick, Joystick::ConnectionState, Joystick::CONNECTION_MAX_ENUM, connectionState)
+
 } // joystick
 } // love

--- a/src/modules/joystick/Joystick.h
+++ b/src/modules/joystick/Joystick.h
@@ -144,6 +144,26 @@ public:
 		INPUT_TYPE_MAX_ENUM
 	};
 
+	enum PowerState
+	{
+		POWERSTATE_ERROR = -1,   /**< error determining power status */
+		POWERSTATE_UNKNOWN,      /**< cannot determine power status */
+		POWERSTATE_ON_BATTERY,   /**< Not plugged in, running on the battery */
+		POWERSTATE_NO_BATTERY,   /**< Plugged in, no battery available */
+		POWERSTATE_CHARGING,     /**< Plugged in, charging battery */
+		POWERSTATE_CHARGED,       /**< Plugged in, battery charged */
+		POWERSTATE_MAX_ENUM
+	};
+
+	enum ConnectionState
+	{
+		CONNECTION_INVALID = -1,
+		CONNECTION_UNKNOWN,
+		CONNECTION_WIRED,
+		CONNECTION_WIRELESS,
+		CONNECTION_MAX_ENUM
+	};
+
 	// Represents a gamepad input value, e.g. the "x" button or the left trigger.
 	struct GamepadInput
 	{
@@ -223,6 +243,8 @@ public:
 	virtual bool isSensorEnabled(Sensor::SensorType type) const = 0;
 	virtual void setSensorEnabled(Sensor::SensorType type, bool enabled) = 0;
 	virtual std::vector<float> getSensorData(Sensor::SensorType type) const = 0;
+	virtual PowerState getPowerInfo(int &batteryPercent) const = 0;
+	virtual ConnectionState getConnectionState() const = 0;
 
 	STRINGMAP_CLASS_DECLARE(Hat);
 	STRINGMAP_CLASS_DECLARE(JoystickType);
@@ -230,6 +252,8 @@ public:
 	STRINGMAP_CLASS_DECLARE(GamepadAxis);
 	STRINGMAP_CLASS_DECLARE(GamepadButton);
 	STRINGMAP_CLASS_DECLARE(InputType);
+	STRINGMAP_CLASS_DECLARE(PowerState);
+	STRINGMAP_CLASS_DECLARE(ConnectionState);
 
 	static float clampval(float x);
 

--- a/src/modules/joystick/sdl/Joystick.cpp
+++ b/src/modules/joystick/sdl/Joystick.cpp
@@ -462,6 +462,40 @@ void Joystick::getDeviceInfo(int &vendorID, int &productID, int &productVersion)
 	}
 }
 
+Joystick::PowerState Joystick::getPowerInfo(int& batteryPercent) const
+{
+	// Gets the battery state of a joystick/gamepad
+	Joystick::PowerState powerState;
+	SDL_PowerState batteryState;
+	if (!isGamepad())
+	{
+		batteryState = SDL_GetJoystickPowerInfo(joyhandle, &batteryPercent);
+	}
+	else
+	{
+		batteryState = SDL_GetGamepadPowerInfo(controller, &batteryPercent);
+	}
+	getConstant(batteryState, powerState);
+	return powerState;
+}
+
+Joystick::ConnectionState Joystick::getConnectionState() const
+{
+	// Gets the connection state of a joystick/gamepad (wired / wireless etc)
+	Joystick::ConnectionState connectionState;
+	SDL_JoystickConnectionState sdlConnectionState;
+	if (!isGamepad())
+	{
+		sdlConnectionState = SDL_GetJoystickConnectionState(joyhandle);
+	}
+	else
+	{
+		sdlConnectionState = SDL_GetGamepadConnectionState(controller);
+	}
+	getConstant(sdlConnectionState, connectionState);
+	return connectionState;
+}
+
 bool Joystick::isVibrationSupported()
 {
 	if (!isConnected())
@@ -614,6 +648,26 @@ bool Joystick::getConstant(Joystick::GamepadButton in, SDL_GamepadButton &out)
 	return gpButtons.find(in, out);
 }
 
+bool Joystick::getConstant(SDL_PowerState in, Joystick::PowerState &out)
+{
+	return powerStates.find(in, out);
+}
+
+bool Joystick::getConstant(Joystick::PowerState in, SDL_PowerState &out)
+{
+	return powerStates.find(in, out);
+}
+
+bool Joystick::getConstant(SDL_JoystickConnectionState in, Joystick::ConnectionState &out)
+{
+	return connectionStates.find(in, out);
+}
+
+bool Joystick::getConstant(Joystick::ConnectionState in, SDL_JoystickConnectionState &out)
+{
+	return connectionStates.find(in, out);
+}
+
 EnumMap<Joystick::Hat, Uint8, Joystick::HAT_MAX_ENUM>::Entry Joystick::hatEntries[] =
 {
 	{Joystick::HAT_CENTERED, SDL_HAT_CENTERED},
@@ -667,6 +721,28 @@ EnumMap<Joystick::GamepadButton, SDL_GamepadButton, Joystick::GAMEPAD_BUTTON_MAX
 };
 
 EnumMap<Joystick::GamepadButton, SDL_GamepadButton, Joystick::GAMEPAD_BUTTON_MAX_ENUM> Joystick::gpButtons(Joystick::gpButtonEntries, sizeof(Joystick::gpButtonEntries));
+
+EnumMap<Joystick::PowerState, SDL_PowerState, Joystick::POWERSTATE_MAX_ENUM>::Entry Joystick::powerStateEntries[] =
+{
+	{Joystick::POWERSTATE_ERROR, SDL_POWERSTATE_ERROR},
+	{Joystick::POWERSTATE_UNKNOWN, SDL_POWERSTATE_UNKNOWN},
+	{Joystick::POWERSTATE_ON_BATTERY, SDL_POWERSTATE_ON_BATTERY},
+	{Joystick::POWERSTATE_NO_BATTERY, SDL_POWERSTATE_NO_BATTERY},
+	{Joystick::POWERSTATE_CHARGING, SDL_POWERSTATE_CHARGING},
+	{Joystick::POWERSTATE_CHARGED, SDL_POWERSTATE_CHARGED},
+};
+
+EnumMap<Joystick::PowerState, SDL_PowerState, Joystick::POWERSTATE_MAX_ENUM> Joystick::powerStates(Joystick::powerStateEntries, sizeof(Joystick::powerStateEntries));
+
+EnumMap<Joystick::ConnectionState, SDL_JoystickConnectionState, Joystick::CONNECTION_MAX_ENUM>::Entry Joystick::connectionStateEntries[] =
+{
+	{Joystick::CONNECTION_INVALID, SDL_JOYSTICK_CONNECTION_INVALID },
+	{Joystick::CONNECTION_UNKNOWN, SDL_JOYSTICK_CONNECTION_UNKNOWN},
+	{Joystick::CONNECTION_WIRED, SDL_JOYSTICK_CONNECTION_WIRED},
+	{Joystick::CONNECTION_WIRELESS, SDL_JOYSTICK_CONNECTION_WIRELESS},
+};
+
+EnumMap<Joystick::ConnectionState, SDL_JoystickConnectionState, Joystick::CONNECTION_MAX_ENUM> Joystick::connectionStates(Joystick::connectionStateEntries, sizeof(Joystick::connectionStateEntries));
 
 } // sdl
 } // joystick

--- a/src/modules/joystick/sdl/Joystick.h
+++ b/src/modules/joystick/sdl/Joystick.h
@@ -84,6 +84,8 @@ public:
 	int getID() const override;
 
 	void getDeviceInfo(int &vendorID, int &productID, int &productVersion) const override;
+	PowerState getPowerInfo(int& batteryPercent) const override;
+	ConnectionState getConnectionState() const override;
 
 	bool isVibrationSupported() override;
 	bool setVibration(float left, float right, float duration = -1.0f) override;
@@ -103,6 +105,12 @@ public:
 
 	static bool getConstant(SDL_GamepadButton in, GamepadButton &out);
 	static bool getConstant(GamepadButton in, SDL_GamepadButton &out);
+
+	static bool getConstant(SDL_PowerState in, PowerState &out);
+	static bool getConstant(PowerState in, SDL_PowerState &out);
+
+	static bool getConstant(SDL_JoystickConnectionState in, ConnectionState &out);
+	static bool getConstant(ConnectionState in, SDL_JoystickConnectionState &out);
 
 private:
 
@@ -129,6 +137,11 @@ private:
 	static EnumMap<GamepadButton, SDL_GamepadButton, GAMEPAD_BUTTON_MAX_ENUM>::Entry gpButtonEntries[];
 	static EnumMap<GamepadButton, SDL_GamepadButton, GAMEPAD_BUTTON_MAX_ENUM> gpButtons;
 
+	static EnumMap<PowerState, SDL_PowerState, POWERSTATE_MAX_ENUM>::Entry powerStateEntries[];
+	static EnumMap<PowerState, SDL_PowerState, POWERSTATE_MAX_ENUM> powerStates;
+
+	static EnumMap<ConnectionState, SDL_JoystickConnectionState, CONNECTION_MAX_ENUM>::Entry connectionStateEntries[];
+	static EnumMap<ConnectionState, SDL_JoystickConnectionState, CONNECTION_MAX_ENUM> connectionStates;
 };
 
 } // sdl

--- a/src/modules/joystick/wrap_Joystick.cpp
+++ b/src/modules/joystick/wrap_Joystick.cpp
@@ -447,6 +447,43 @@ int w_Joystick_getSensorData(lua_State *L)
 	return (int) data.size();
 }
 
+int w_Joystick_getDeviceBatteryPercent(lua_State *L)
+{
+	Joystick *j = luax_checkjoystick(L, 1);
+
+	int batteryPercent = 0;
+	j->getPowerInfo(batteryPercent);
+
+	lua_pushnumber(L, batteryPercent);
+
+	return 1;
+}
+
+int w_Joystick_getDevicePowerState(lua_State *L)
+{
+	Joystick *j = luax_checkjoystick(L, 1);
+
+	int batteryPercent = 0;
+	const char *str = "unknown";
+	Joystick::getConstant(j->getPowerInfo(batteryPercent), str);
+
+	lua_pushstring(L, str);
+
+	return 1;
+}
+
+int w_Joystick_getDeviceConnectionState(lua_State *L)
+{
+	Joystick *j = luax_checkjoystick(L, 1);
+
+	const char *str = "unknown";
+	Joystick::getConstant(j->getConnectionState(), str);
+
+	lua_pushstring(L, str);
+
+	return 1;
+}
+
 #endif // LOVE_ENABLE_SENSOR
 
 // List of functions to wrap.
@@ -457,6 +494,9 @@ static const luaL_Reg w_Joystick_functions[] =
 	{ "getID", w_Joystick_getID },
 	{ "getGUID", w_Joystick_getGUID },
 	{ "getDeviceInfo", w_Joystick_getDeviceInfo },
+	{ "getDeviceBatteryPercent", w_Joystick_getDeviceBatteryPercent },
+	{ "getDevicePowerState", w_Joystick_getDevicePowerState },
+	{ "getDeviceConnectionState", w_Joystick_getDeviceConnectionState },
 	{ "getJoystickType", w_Joystick_getJoystickType },
 	{ "getAxisCount", w_Joystick_getAxisCount },
 	{ "getButtonCount", w_Joystick_getButtonCount },


### PR DESCRIPTION
This pull implements the api to call the following:
https://wiki.libsdl.org/SDL3/SDL_GetJoystickPowerInfo
https://wiki.libsdl.org/SDL3/SDL_GetJoystickConnectionState
https://wiki.libsdl.org/SDL3/SDL_GetGamepadPowerInfo
https://wiki.libsdl.org/SDL3/SDL_GetGamepadConnectionState

It's worth noting though, the battery info returned from PowerInfo they have on the wiki:
_You should never take a battery status as absolute truth. Batteries (especially failing batteries) are delicate hardware, and the values reported here are best estimates based on what that hardware reports. It's not uncommon for older batteries to lose stored power much faster than it reports, or completely drain when reporting it has 20 percent left, etc._

I found this in testing, I tried a wireless steam controller on battery and it did not report any battery percent. Other controllers may though. Even when using the SDL testcontroller it did not report anything.

Testing wired though with the following script works as expected
```
function love.draw()
    local sticks = love.joystick:getJoysticks()
    for _, stick in ipairs(sticks) do
        local name = stick:getName()
        local id = stick:getID()
        local battery = stick:getDeviceBatteryPercent()
        local power = stick:getDevicePowerState()
        local connection = stick:getDeviceConnectionState()

        love.graphics.print("name: " .. name, 100, 100)
        love.graphics.print("id: " .. id, 100, 120)
        love.graphics.print("battery power state: " .. power, 100, 140)
        love.graphics.print("battery percent: " .. battery, 100, 160)
        love.graphics.print("connection state: " .. connection, 100, 180)
    end
end

```
<img width="815" height="646" alt="image" src="https://github.com/user-attachments/assets/8066814a-8fc2-42c0-9385-bf34ef9d510f" />

I suspect this somewhat resolves #2223
