### PR TITLE
Fix renderSegment reversed range logic and align rounding behavior.

### DIFF
--- a/src/modules/math/BezierCurve.cpp
+++ b/src/modules/math/BezierCurve.cpp
@@ -266,10 +266,10 @@ vector<Vector2> BezierCurve::renderSegment(double start, double end, int accurac
 		size_t end_idx = size_t(end * vertices.size() + 0.5);
 		return std::vector<Vector2>(vertices.begin() + start_idx, vertices.begin() + end_idx);
 	}
-	else if (end > start)
+	else if (start > end)
 	{
-		size_t start_idx = size_t(end * vertices.size() + 0.5);
-		size_t end_idx = size_t(start * vertices.size());
+		size_t start_idx = size_t(end * vertices.size());
+		size_t end_idx = size_t(start * vertices.size() + 0.5);
 		return std::vector<Vector2>(vertices.begin() + start_idx, vertices.begin() + end_idx);
 	}
 	return vertices;


### PR DESCRIPTION
Fixes #2238

---

This PR fixes two issues in BezierCurve::renderSegment:

- **Reversed argument handling (start > end)**
The existing `else if (end > start)` branch was unreachable due to the
preceding `start < end` check. As a result, calling `renderSegment` with
reversed parameters returned the full curve instead of the intended subrange.
The condition is corrected so reversed ranges now slice the proper segment.

- **Asymmetric rounding when slicing sampled vertices**
The forward and reversed paths previously used different rounding rules,
causing `renderSegment(a, b)` and `renderSegment(b, a)` to select slightly
different vertex ranges. Index calculation is now normalized so both cases
refer to the same portion of the sampled curve.

---

**Result**

`renderSegment` now handles reversed arguments consistently and returns the
correct sub-curve in both orders, with stable and predictable indexing.