### PR TITLE
Minor Bug Fix: Ensure full traceback is processed by appending a newline

### DIFF
--- a/src/modules/love/callbacks.lua
+++ b/src/modules/love/callbacks.lua
@@ -273,7 +273,7 @@ function love.errorhandler(msg)
 	end
 
 	table.insert(err, "\n")
-	
+
 	for l in trace:gmatch("([^\n]+)") do
 		if not l:match("boot.lua") then
 			l = l:gsub("stack traceback:", "Traceback\n")


### PR DESCRIPTION
I'm unsure for other users, but on windows `debug.traceback` doesn't return a string with a trailing new line. Which the capture that processes the traceback expects in the default errorhandler. So, the string pattern used, always misses the last line of a traceback from displaying.

So, I've applied a fix by adding a trailing new line if there is one missing. This way the capture pattern now grabs all of the lines of the trace.
