### PR TITLE
Fix buffer range merging in HarfbuzzShaper to check cluster contiguity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ stamp-h1
 /testing/output/*.md
 /testing/output/actual/*.png
 /testing/output/difference/*.png
+
+/test_issue*
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,3 @@ stamp-h1
 /testing/output/*.md
 /testing/output/actual/*.png
 /testing/output/difference/*.png
-
-/test_issue*
-build/


### PR DESCRIPTION
The correction for when fallback fonts are used. Correction for this [issue](https://github.com/love2d/love/issues/1990)

main.lua required to replicate this issue
```lua
function love.load()
    local main = love.graphics.newFont("fonts/NotoSans-Regular.ttf", 32)
    local symbols = love.graphics.newFont("fonts/NotoSansSymbols2-Regular.ttf", 32)
    main:setFallbacks(symbols)
    love.graphics.setFont(main)
end

function love.draw()
    love.graphics.print("a⇨b⇨c", 50, 50)
    love.graphics.print("1⇦2⇨3⇧4⇩5", 50, 100)
end
```