### PR TITLE
ByteData:setString: Fix Error Handling

### DIFF
--- a/src/modules/data/wrap_ByteData.cpp
+++ b/src/modules/data/wrap_ByteData.cpp
@@ -51,9 +51,7 @@ int w_ByteData_setString(lua_State *L)
 	const char *str = luaL_checklstring(L, 2, &size);
 	int64 offset = (int64)luaL_optnumber(L, 3, 0);
 
-	size = std::min(size, t->getSize());
-
-	if (size == 0)
+	if (size == 0) 
 		return 0;
 
 	if (offset < 0 || offset + (int64) size > (int64) t->getSize())


### PR DESCRIPTION
While working on a library of mine, I noticed that the following code did not produce an error:
```lua
local data = love.data.newByteData(4)
data:setString("This is an example")
```
I looked at the implementation of `ByteData:setString` and it always sets the minimum size to either the string length or data size, whichever is smaller. In this example, I'm writing a string with length of 18 into a ByteData with a size of 4. This gets clamped to 4, preventing the error message from showing up. It does make sense to make sure that the size of the data being written is within bounds, but I think the expectation here was to error, not silently fail. I removed the `std::min` call, but if the size is 0, still return nothing back to the Lua stack, since there is nothing to write.