### PR TITLE
feat(ohos): add initial OpenHarmony platform support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE) # Needed for shared libs on Linux. (-f
 set(CMAKE_CXX_STANDARD 17)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)	# Allow grouping projects in Visual Studio
 
+if(CMAKE_SYSTEM_NAME MATCHES "OHOS|OpenHarmony|HarmonyOS")
+	add_compile_definitions(LOVE_OHOS=1)
+endif()
+
 if(APPLE)
 	message(WARNING "CMake is not an officially supported build system for love on Apple platforms.")
 	message(WARNING "Use the prebuilt .app or the xcode project in platform/xcode/ instead.")
@@ -243,6 +247,8 @@ endfunction()
 add_library(love_common STATIC
 	src/common/android.cpp
 	src/common/android.h
+	src/common/ohos.cpp
+	src/common/ohos.h
 	src/common/b64.cpp
 	src/common/b64.h
 	src/common/Color.h
@@ -1989,9 +1995,11 @@ endif()
 #
 # love (executable)
 #
-if(ANDROID)
+if(ANDROID OR CMAKE_SYSTEM_NAME MATCHES "OHOS|OpenHarmony|HarmonyOS")
 	add_library(love SHARED) # On Android, the LOVE main entrypoint needs to be compiled as shared library
-	target_link_libraries(liblove android)
+	if(ANDROID)
+		target_link_libraries(liblove android)
+	endif()
 else()
 	add_executable(love WIN32)
 endif()

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -21,7 +21,7 @@
 #ifndef LOVE_CONFIG_H
 #define LOVE_CONFIG_H
 
-// Platform stuff.
+ // Platform stuff.
 #if defined(WIN32) || defined(_WIN32)
 #	define LOVE_WINDOWS 1
 #	include <winapifamily.h>
@@ -36,6 +36,10 @@
 #if defined(__ANDROID__)
 #	define LOVE_ANDROID 1
 // Needed for ENet
+#	define HAS_SOCKLEN_T 1
+#endif
+#if defined(OHOS) || defined(__OHOS__)
+#	define LOVE_OHOS 1
 #	define HAS_SOCKLEN_T 1
 #endif
 #if defined(__APPLE__)
@@ -123,7 +127,7 @@
 #	define LOVE_LEGENDARY_APP_ARGV_HACK
 #endif
 
-#if defined(LOVE_WINDOWS) || defined(LOVE_LINUX) || defined(LOVE_ANDROID)
+#if defined(LOVE_WINDOWS) || defined(LOVE_LINUX) || defined(LOVE_ANDROID) || defined(LOVE_OHOS)
 #	define LOVE_GRAPHICS_VULKAN
 #endif
 

--- a/src/common/ohos.cpp
+++ b/src/common/ohos.cpp
@@ -1,0 +1,73 @@
+#include "config.h"
+
+#ifdef LOVE_OHOS
+
+#include "ohos.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+namespace love
+{
+namespace ohos
+{
+
+static std::string g_sandboxPath;
+static std::string g_gameResourcePath;
+
+static bool directoryExists(const char *path)
+{
+	struct stat st;
+	return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+static bool tryCreateDirectory(const std::string &path)
+{
+	if (path.empty())
+		return false;
+	if (directoryExists(path.c_str()))
+		return true;
+	return ::mkdir(path.c_str(), 0755) == 0;
+}
+
+void setSandboxPath(const char *path)
+{
+	g_sandboxPath = path ? path : "";
+}
+
+const std::string &getSandboxPath()
+{
+	return g_sandboxPath;
+}
+
+void setGameResourcePath(const char *path)
+{
+	g_gameResourcePath = path ? path : "";
+}
+
+const std::string &getGameResourcePath()
+{
+	return g_gameResourcePath;
+}
+
+bool createStorageDirectories()
+{
+	if (g_sandboxPath.empty())
+		return false;
+
+	if (!tryCreateDirectory(g_sandboxPath))
+		return false;
+
+	if (!tryCreateDirectory(g_sandboxPath + "/save"))
+		return false;
+
+	if (!tryCreateDirectory(g_sandboxPath + "/game"))
+		return false;
+
+	return true;
+}
+
+} // namespace ohos
+} // namespace love
+
+#endif

--- a/src/common/ohos.h
+++ b/src/common/ohos.h
@@ -1,0 +1,22 @@
+#ifndef LOVE_OHOS_H
+#define LOVE_OHOS_H
+
+#include <string>
+
+namespace love
+{
+namespace ohos
+{
+
+void setSandboxPath(const char *path);
+const std::string &getSandboxPath();
+
+void setGameResourcePath(const char *path);
+const std::string &getGameResourcePath();
+
+bool createStorageDirectories();
+
+} // namespace ohos
+} // namespace love
+
+#endif

--- a/src/love.cpp
+++ b/src/love.cpp
@@ -29,11 +29,11 @@
 
 #include <SDL3/SDL_main.h>
 
-// Lua
+ // Lua
 extern "C" {
-	#include <lua.h>
-	#include <lualib.h>
-	#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
 }
 
 #ifdef LOVE_WINDOWS
@@ -54,15 +54,15 @@ extern "C" {
 extern "C"
 {
 
-// Prefer the higher performance GPU on Windows systems that use nvidia Optimus.
-// http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf
-// TODO: Re-evaluate in the future when the average integrated GPU in Optimus
-// systems is less mediocre?
-LOVE_EXPORT DWORD NvOptimusEnablement = 1;
+	// Prefer the higher performance GPU on Windows systems that use nvidia Optimus.
+	// http://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf
+	// TODO: Re-evaluate in the future when the average integrated GPU in Optimus
+	// systems is less mediocre?
+	LOVE_EXPORT DWORD NvOptimusEnablement = 1;
 
-// Same with AMD GPUs.
-// https://community.amd.com/thread/169965
-LOVE_EXPORT DWORD AmdPowerXpressRequestHighPerformance = 1;
+	// Same with AMD GPUs.
+	// https://community.amd.com/thread/169965
+	LOVE_EXPORT DWORD AmdPowerXpressRequestHighPerformance = 1;
 }
 #endif // LOVE_WINDOWS
 
@@ -152,17 +152,17 @@ enum DoneAction
 
 static void print_usage()
 {
-    // when editing this message, change it at boot.lua too
-    printf("LOVE is an *awesome* framework you can use to make 2D games in Lua\n"
-        "https://love2d.org\n"
-        "\n"
-        "usage:\n"
-        "    love --version                  prints LOVE version and quits\n"
-        "    love --help                     prints this message and quits\n"
-        "    love path/to/gamedir            runs the game from the given directory which contains a main.lua file\n"
-        "    love path/to/packagedgame.love  runs the packaged game from the provided .love file\n"
-        "    love path/to/file.lua           runs the game from the given .lua file\n"
-        );
+	// when editing this message, change it at boot.lua too
+	printf("LOVE is an *awesome* framework you can use to make 2D games in Lua\n"
+		"https://love2d.org\n"
+		"\n"
+		"usage:\n"
+		"    love --version                  prints LOVE version and quits\n"
+		"    love --help                     prints this message and quits\n"
+		"    love path/to/gamedir            runs the game from the given directory which contains a main.lua file\n"
+		"    love path/to/packagedgame.love  runs the packaged game from the provided .love file\n"
+		"    love path/to/file.lua           runs the game from the given .lua file\n"
+	);
 }
 
 static DoneAction runlove(int argc, char **argv, int &retval, love::Variant &restartvalue)
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
 	if (strcmp(LOVE_VERSION_STRING, love_version()) != 0)
 	{
 		printf("Version mismatch detected!\nLOVE binary is version %s\n"
-			   "LOVE library is version %s\n", LOVE_VERSION_STRING, love_version());
+			"LOVE library is version %s\n", LOVE_VERSION_STRING, love_version());
 		return 1;
 	}
 
@@ -327,11 +327,16 @@ int main(int argc, char **argv)
 #endif
 	} while (done != DONE_QUIT);
 
-#ifdef LOVE_ANDROID
+#if defined(LOVE_ANDROID) || defined(LOVE_OHOS)
 	SDL_Quit();
 #endif
 
 	return retval;
+}
+
+extern "C" LOVE_EXPORT int love_run(int argc, char **argv)
+{
+	return main(argc, argv);
 }
 
 #endif // LOVE_BUILD_EXE

--- a/src/modules/audio/openal/Audio.cpp
+++ b/src/modules/audio/openal/Audio.cpp
@@ -202,7 +202,7 @@ Audio::Audio()
 
 	poolThread = new PoolThread(pool);
 	poolThread->start();
-	
+
 #ifdef LOVE_IOS
 	love::ios::initAudioSessionInterruptionHandler();
 #endif
@@ -210,10 +210,10 @@ Audio::Audio()
 #ifdef LOVE_ANDROID
 	bool hasPauseDeviceExt = alcIsExtensionPresent(device, "ALC_SOFT_pause_device") == ALC_TRUE;
 	alcDevicePauseSOFT = hasPauseDeviceExt
-		? (LPALCDEVICEPAUSESOFT) alcGetProcAddress(device, "alcDevicePauseSOFT")
+		? (LPALCDEVICEPAUSESOFT)alcGetProcAddress(device, "alcDevicePauseSOFT")
 		: nullptr;
 	alcDeviceResumeSOFT = hasPauseDeviceExt
-		? (LPALCDEVICERESUMESOFT) alcGetProcAddress(device, "alcDeviceResumeSOFT")
+		? (LPALCDEVICERESUMESOFT)alcGetProcAddress(device, "alcDeviceResumeSOFT")
 		: nullptr;
 #endif
 }
@@ -321,7 +321,7 @@ bool Audio::play(love::audio::Source *source)
 	return source->play();
 }
 
-bool Audio::play(const std::vector<love::audio::Source*> &sources)
+bool Audio::play(const std::vector<love::audio::Source *> &sources)
 {
 	return Source::play(sources);
 }
@@ -331,7 +331,7 @@ void Audio::stop(love::audio::Source *source)
 	source->stop();
 }
 
-void Audio::stop(const std::vector<love::audio::Source*> &sources)
+void Audio::stop(const std::vector<love::audio::Source *> &sources)
 {
 	return Source::stop(sources);
 }
@@ -346,12 +346,12 @@ void Audio::pause(love::audio::Source *source)
 	source->pause();
 }
 
-void Audio::pause(const std::vector<love::audio::Source*> &sources)
+void Audio::pause(const std::vector<love::audio::Source *> &sources)
 {
 	return Source::pause(sources);
 }
 
-std::vector<love::audio::Source*> Audio::pause()
+std::vector<love::audio::Source *> Audio::pause()
 {
 	return Source::pause(pool);
 }
@@ -366,10 +366,10 @@ void Audio::pauseContext()
 		// This is extremely rare case since we're using OpenAL-soft
 		// in Android and the ALC_SOFT_pause_device has been supported
 		// since 1.16
-		for (auto &src: pausedSources)
+		for (auto &src : pausedSources)
 			src->release();
 		pausedSources = pause();
-		for (auto &src: pausedSources)
+		for (auto &src : pausedSources)
 			src->retain();
 	}
 #else
@@ -386,7 +386,7 @@ void Audio::resumeContext()
 	{
 		// Again, this is rare case
 		play(pausedSources);
-		for (auto &src: pausedSources)
+		for (auto &src : pausedSources)
 			src->release();
 		pausedSources.resize(0);
 	}
@@ -423,11 +423,11 @@ void Audio::getPlaybackDevices(std::vector<std::string> &list)
 void Audio::setPlaybackDevice(const char *name)
 {
 #ifndef ALC_SOFT_reopen_device
-	typedef ALCboolean (ALC_APIENTRY*LPALCREOPENDEVICESOFT)(ALCdevice *device,
+	typedef ALCboolean(ALC_APIENTRY *LPALCREOPENDEVICESOFT)(ALCdevice *device,
 		const ALCchar *deviceName, const ALCint *attribs);
 #endif
 	static LPALCREOPENDEVICESOFT alcReopenDeviceSOFT = alcIsExtensionPresent(device, "ALC_SOFT_reopen_device") == ALC_TRUE
-		? (LPALCREOPENDEVICESOFT) alcGetProcAddress(device, "alcReopenDeviceSOFT")
+		? (LPALCREOPENDEVICESOFT)alcGetProcAddress(device, "alcReopenDeviceSOFT")
 		: nullptr;
 
 	if (alcReopenDeviceSOFT == nullptr)
@@ -440,7 +440,7 @@ void Audio::setPlaybackDevice(const char *name)
 
 	std::vector<ALint> attribs = computeContextAttribs();
 
-	if (alcReopenDeviceSOFT(device, (const ALCchar *) name, attribs.data()) == ALC_FALSE)
+	if (alcReopenDeviceSOFT(device, (const ALCchar *)name, attribs.data()) == ALC_FALSE)
 		throw love::Exception("Cannot set output device: %s", alcGetString(device, alcGetError(device)));
 }
 
@@ -557,10 +557,10 @@ void Audio::setDistanceModel(DistanceModel distanceModel)
 	}
 }
 
-const std::vector<love::audio::RecordingDevice*> &Audio::getRecordingDevices()
+const std::vector<love::audio::RecordingDevice *> &Audio::getRecordingDevices()
 {
 	std::vector<std::string> devnames;
-	std::vector<love::audio::RecordingDevice*> devices;
+	std::vector<love::audio::RecordingDevice *> devices;
 
 	// If recording permission is not granted, inform user about it
 	// and return empty list.
@@ -601,7 +601,7 @@ const std::vector<love::audio::RecordingDevice*> &Audio::getRecordingDevices()
 	{
 		if (devstr[offset] == '\0')
 			break;
-		std::string str((ALCchar*)&devstr[offset]);
+		std::string str((ALCchar *)&devstr[offset]);
 		if (str != defaultname)
 			devnames.push_back(str);
 		offset += str.length() + 1;
@@ -609,7 +609,7 @@ const std::vector<love::audio::RecordingDevice*> &Audio::getRecordingDevices()
 
 	devices.reserve(devnames.size());
 	//build ordered list of devices
-	for (int i = 0; i < (int) devnames.size(); i++)
+	for (int i = 0; i < (int)devnames.size(); i++)
 	{
 		devices.push_back(nullptr);
 		auto d = devices.end() - 1;
@@ -652,7 +652,7 @@ bool Audio::setEffect(const char *name, std::map<Effect::Parameter, float> &para
 		slot = slotlist.top();
 		slotlist.pop();
 
-		effectmap[name] = {effect, slot};
+		effectmap[name] = { effect, slot };
 	}
 	else
 	{

--- a/src/modules/filesystem/physfs/Filesystem.cpp
+++ b/src/modules/filesystem/physfs/Filesystem.cpp
@@ -66,12 +66,31 @@
 #include "common/android.h"
 #endif
 
+#ifdef LOVE_OHOS
+#include "common/ohos.h"
+#include <sys/stat.h>
+#endif
+
 namespace love
 {
 namespace filesystem
 {
 namespace physfs
 {
+
+#ifdef LOVE_OHOS
+static bool osFileExists(const char *path)
+{
+	struct stat st;
+	return path && stat(path, &st) == 0 && S_ISREG(st.st_mode);
+}
+
+static bool osDirectoryExists(const char *path)
+{
+	struct stat st;
+	return path && stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+#endif
 
 static std::string normalize(const std::string &input)
 {
@@ -314,6 +333,37 @@ bool Filesystem::setSource(const char *source)
 	}
 	catch (const love::Exception &)
 	{}
+#endif
+
+#ifdef LOVE_OHOS
+	love::ohos::createStorageDirectories();
+
+	const std::string &resourcePath = love::ohos::getGameResourcePath();
+	if (!resourcePath.empty())
+	{
+		std::string mainlua = resourcePath + "/main.lua";
+		std::string gamelove = resourcePath + "/game.love";
+
+		if (osDirectoryExists(resourcePath.c_str()) && osFileExists(mainlua.c_str()))
+		{
+			std::string canon = canonicalizeRealPath(resourcePath);
+			if (!isMounted(canon) && PHYSFS_mount(canon.c_str(), nullptr, 1))
+			{
+				gameSource = canon;
+				return true;
+			}
+		}
+
+		if (osFileExists(gamelove.c_str()))
+		{
+			std::string canon = canonicalizeRealPath(gamelove);
+			if (!isMounted(canon) && PHYSFS_mount(canon.c_str(), nullptr, 1))
+			{
+				gameSource = canon;
+				return true;
+			}
+		}
+	}
 #endif
 
 	if (isMounted(new_search_path))
@@ -701,6 +751,32 @@ std::string Filesystem::getFullCommonPath(CommonPath path)
 	case COMMONPATH_USER_DOCUMENTS:
 		// TODO: something more idiomatic / useful?
 		fullPaths[path] = normalize(storagepath + "/Documents/");
+		break;
+	case COMMONPATH_MAX_ENUM:
+		break;
+	}
+
+#elif defined(LOVE_OHOS)
+
+	std::string base = love::ohos::getSandboxPath();
+	if (base.empty())
+		base = normalize(PHYSFS_getUserDir());
+
+	switch (path)
+	{
+	case COMMONPATH_APP_SAVEDIR:
+	case COMMONPATH_APP_DOCUMENTS:
+		break;
+	case COMMONPATH_USER_HOME:
+		fullPaths[path] = normalize(PHYSFS_getUserDir());
+		break;
+	case COMMONPATH_USER_APPDATA:
+		fullPaths[path] = normalize(base + "/save/");
+		break;
+	case COMMONPATH_USER_DESKTOP:
+		break;
+	case COMMONPATH_USER_DOCUMENTS:
+		fullPaths[path] = normalize(base + "/Documents/");
 		break;
 	case COMMONPATH_MAX_ENUM:
 		break;

--- a/src/modules/system/System.cpp
+++ b/src/modules/system/System.cpp
@@ -50,6 +50,8 @@ const char *System::getOS()
 	return "Windows";
 #elif defined(LOVE_ANDROID)
 	return "Android";
+#elif defined(LOVE_OHOS)
+	return "OHOS";
 #elif defined(LOVE_LINUX)
 	return "Linux";
 #else
@@ -63,6 +65,8 @@ void System::vibrate(double seconds) const
 	love::android::vibrate(seconds);
 #elif defined(LOVE_IOS)
 	love::ios::vibrate();
+#elif defined(LOVE_OHOS)
+	LOVE_UNUSED(seconds);
 #else
 	LOVE_UNUSED(seconds);
 #endif
@@ -74,6 +78,8 @@ bool System::hasBackgroundMusic() const
 	return love::android::hasBackgroundMusic();
 #elif defined(LOVE_IOS)
 	return love::ios::hasBackgroundMusic();
+#elif defined(LOVE_OHOS)
+	return false;
 #else
 	return false;
 #endif


### PR DESCRIPTION
Add basic platform detection, system module adaptations, and filesystem handling for OpenHarmony (OHOS). This includes:
- New ohos.cpp/ohos.h for sandbox and resource path management
- CMake build system integration with LOVE_OHOS definition
- System module returning "OHOS" OS name and stubbing vibration/background music
- Filesystem module mounting game resources from OHOS-specific paths
- Audio and main entrypoint adjustments for shared library compatibility
- Config.h updates to enable Vulkan graphics on OHOS

The changes allow LOVE2D games to run on OpenHarmony devices with proper storage isolation and resource loading.