### PR TITLE
love.window.setPosition: add param waitForSync

### DIFF
--- a/src/modules/window/Window.h
+++ b/src/modules/window/Window.h
@@ -189,7 +189,7 @@ public:
 
 	virtual void getDesktopDimensions(int displayindex, int &width, int &height) const = 0;
 
-	virtual void setPosition(int x, int y, int displayindex) = 0;
+	virtual void setPosition(int x, int y, int displayindex, bool waitForSync) = 0;
 	virtual void getPosition(int &x, int &y, int &displayindex) = 0;
 
 	virtual Rect getSafeArea() const = 0;

--- a/src/modules/window/sdl/Window.cpp
+++ b/src/modules/window/sdl/Window.cpp
@@ -957,7 +957,7 @@ void Window::getDesktopDimensions(int displayindex, int &width, int &height) con
 	}
 }
 
-void Window::setPosition(int x, int y, int displayindex)
+void Window::setPosition(int x, int y, int displayindex, bool waitForSync)
 {
 	if (!window)
 		return;
@@ -974,7 +974,8 @@ void Window::setPosition(int x, int y, int displayindex)
 	y += displaybounds.y;
 
 	SDL_SetWindowPosition(window, x, y);
-	SDL_SyncWindow(window);
+	if (waitForSync)
+		SDL_SyncWindow(window);
 
 	settings.useposition = true;
 }

--- a/src/modules/window/sdl/Window.h
+++ b/src/modules/window/sdl/Window.h
@@ -66,7 +66,7 @@ public:
 
 	void getDesktopDimensions(int displayindex, int &width, int &height) const override;
 
-	void setPosition(int x, int y, int displayindex) override;
+	void setPosition(int x, int y, int displayindex, bool waitForSync) override;
 	void getPosition(int &x, int &y, int &displayindex) override;
 
 	Rect getSafeArea() const override;

--- a/src/modules/window/wrap_Window.cpp
+++ b/src/modules/window/wrap_Window.cpp
@@ -384,8 +384,9 @@ int w_setPosition(lua_State *L)
 		int x_unused, y_unused;
 		instance()->getPosition(x_unused, y_unused, displayindex);
 	}
+	bool waitForSync = luax_optboolean(L, 4, true);
 
-	instance()->setPosition(x, y, displayindex);
+	instance()->setPosition(x, y, displayindex, waitForSync);
 	return 0;
 }
 


### PR DESCRIPTION
if waitForSync is false, then SDL_SyncWindow is not called, and so the method may return before the requested changes actually happen.

This is backwards-compatible with previous behaviour

- [x] I confirm that any code in this pull request that is not authored by me has proper attribution and licensing included, and that this pull request does not include any output from generative AI / LLM tools.
