### PR TITLE
Fix zlib decompression incomplete data check

### DIFF
--- a/src/modules/data/Compressor.cpp
+++ b/src/modules/data/Compressor.cpp
@@ -246,7 +246,7 @@ private:
 		if (err != Z_STREAM_END)
 		{
 			inflateEnd(&stream);
-			if (err == Z_NEED_DICT || (err == Z_BUF_ERROR && stream.avail_in == 0))
+			if (err == Z_NEED_DICT || (err == Z_BUF_ERROR && stream.avail_out > 0 && stream.avail_in == 0))
 				return Z_DATA_ERROR;
 			return err;
 		}


### PR DESCRIPTION
- [x] I confirm that all code in this pull request is either authored by me or has proper attribution and licensing included, and that this pull request does not include any output from generative AI / LLM tools.

## Description
<!-- Describe the change here. For new features, it's best if there's an existing discussion in the issue tracker, Discord server, or other community spaces where the feature's design can be iterated on before making a pull request. -->

Fixes a bug with zlib deflate decompression functions falsely detecting compressed data as incomplete.

## Related Issues
<!-- Link any related Github issues here. Use Github's 'Fixes #1234' syntax if merging this pull request should close an issue. -->

Fixes #2317