### PR TITLE
Add 'inverseOf' to love.Transform

### DIFF
--- a/src/modules/math/wrap_Transform.cpp
+++ b/src/modules/math/wrap_Transform.cpp
@@ -145,9 +145,7 @@ int w_Transform_inverseOf(lua_State *L)
 {
 	Transform *destination = luax_checktransform(L, 1);
 	Transform *source = luax_checktransform(L, 2);
-	Transform *inverseSource = source->inverse();
-	destination->setMatrix(inverseSource->getMatrix());
-	inverseSource->release();
+	destination->setMatrix(source->getMatrix().inverse());
 	lua_pushvalue(L, 1);
 	return 1;
 }

--- a/src/modules/math/wrap_Transform.cpp
+++ b/src/modules/math/wrap_Transform.cpp
@@ -141,6 +141,17 @@ int w_Transform_inverse(lua_State *L)
 	return 1;
 }
 
+int w_Transform_inverseOf(lua_State *L)
+{
+	Transform *destination = luax_checktransform(L, 1);
+	Transform *source = luax_checktransform(L, 2);
+	Transform *inverseSource = source->inverse();
+	destination->setMatrix(inverseSource->getMatrix());
+	inverseSource->release();
+	lua_pushvalue(L, 1);
+	return 1;
+}
+
 int w_Transform_apply(lua_State *L)
 {
 	Transform *t = luax_checktransform(L, 1);
@@ -298,6 +309,7 @@ static const luaL_Reg functions[] =
 {
 	{ "clone", w_Transform_clone },
 	{ "inverse", w_Transform_inverse },
+	{ "inverseOf", w_Transform_inverseOf },
 	{ "apply", w_Transform_apply },
 	{ "isAffine2DTransform", w_Transform_isAffine2DTransform },
 	{ "translate", w_Transform_translate },

--- a/testing/tests/math.lua
+++ b/testing/tests/math.lua
@@ -145,6 +145,16 @@ love.test.math.Transform = function(test)
   px, py = transform:transformPoint(0, 0)
   test:assertCoords({-px, -py}, {ipx, ipy}, 'check inverse points transform')
 
+  -- check inverse and inverseOf produce same values
+  transform:reset()
+  transform:setTransformation(4, 4, math.pi / 2, 2, 2)
+  local inverseClone = transform:inverse()
+  local inverseDestinationTransform = love.math.newTransform()
+  inverseDestinationTransform:inverseOf(transform)
+  local opx1, opy1 = inverseClone:transformPoint(0, 0)
+  local opx2, opy2 = inverseDestinationTransform:transformPoint(0, 0)
+  test:assertCoords({opx1, opy1}, {opx2, opy2}, 'check inverse and inverseOf produce same values')
+
   -- check matrix manipulation
   transform:setTransformation(0, 0, 0, 1, 1, 0, 0, 0, 0)
   transform:translate(4, 4)


### PR DESCRIPTION
- [x] I confirm that all code in this pull request is either authored by me or has proper attribution and licensing included, and that this pull request does not include any output from generative AI / LLM tools.

## Description
Add 'inverseOf' that copies the inverse of the parameter (`source`) to the transform `self`. This is to provide a means to prevent generating garbage when getting the inverse of a transform. Generally you can use all of the `Transform` methods without generating garbage as it stands... except when computing the inverse. See Discord discussion: https://discord.com/channels/329400828920070144/516361887840075812/1517506663379238993

I'm unsure of the name - took Sasha's suggestion from Discord.

Personally, my use case is for a three/four dimensional `inverseTransformPoint` sort of equivalent (e.g., `project` and `unproject` equivalents for 3D) using `love.Transform` without generating garbage. I'd like to use the underlying `love.Transform` when `send`ing to shaders, `setProjection`/`applyTransform`, etc and not have to marshal between a Lua/LuaJIT-native `mat4`-equivalent type and `love.Transform`. Can imagine lots of other uses - skeletal animation (e.g., a Lua/LOVE Spine runtime) etc. And a way to avoid generating garbage is always cool. :)

If this is too niche, that's fine. Just thought I'd propose it!

## Related Issues
N/A
