### PR TITLE
Opus decoder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ add_library(lovedep::Modplug INTERFACE IMPORTED)
 add_library(lovedep::Theora INTERFACE IMPORTED)
 add_library(lovedep::Vorbis INTERFACE IMPORTED)
 add_library(lovedep::Ogg INTERFACE IMPORTED)
+add_library(lovedep::Opus INTERFACE IMPORTED)
 add_library(lovedep::Zlib INTERFACE IMPORTED)
 add_library(lovedep::Lua INTERFACE IMPORTED)
 
@@ -206,6 +207,10 @@ Please see https://github.com/love2d/megasource
 	find_package(Ogg REQUIRED)
 	target_include_directories(lovedep::Ogg INTERFACE ${OGG_INCLUDE_DIR})
 	target_link_libraries(lovedep::Ogg INTERFACE ${OGG_LIBRARY})
+
+	find_package(Opus REQUIRED)
+	target_include_directories(lovedep::Opus INTERFACE ${OPUS_INCLUDE_DIR} ${OPUS_INCLUDE_DIR}/opus)
+	target_link_libraries(lovedep::Opus INTERFACE ${OPUSFILE_LIBRARY})
 
 	find_package(ZLIB REQUIRED)
 	target_include_directories(lovedep::Zlib INTERFACE ${ZLIB_INCLUDE_DIRS})
@@ -1061,6 +1066,8 @@ add_library(love_sound_lullaby STATIC
 	src/modules/sound/lullaby/Sound.h
 	src/modules/sound/lullaby/VorbisDecoder.cpp
 	src/modules/sound/lullaby/VorbisDecoder.h
+	src/modules/sound/lullaby/OpusDecoder.cpp
+	src/modules/sound/lullaby/OpusDecoder.h
 	src/modules/sound/lullaby/WaveDecoder.cpp
 	src/modules/sound/lullaby/WaveDecoder.h
 )
@@ -1068,6 +1075,7 @@ target_link_libraries(love_sound_lullaby PUBLIC
 	lovedep::Modplug
 	lovedep::Vorbis
 	lovedep::Ogg
+	lovedep::Opus
 )
 
 add_library(love_sound INTERFACE)

--- a/extra/cmake/FindOpus.cmake
+++ b/extra/cmake/FindOpus.cmake
@@ -1,0 +1,30 @@
+# Sets the following variables:
+#
+# OPUS_FOUND
+# OPUS_INCLUDE_DIR
+# OPUS_LIBRARY
+# OPUSFILE_LIBRARY
+
+set(OPUS_SEARCH_PATHS
+	/usr/local
+	/usr
+	)
+
+find_path(OPUS_INCLUDE_DIR opus
+	PATH_SUFFIXES include
+	PATHS ${OPUS_SEARCH_PATHS})
+
+find_library(OPUS_LIBRARY
+	NAMES opus
+	PATH_SUFFIXES lib
+	PATHS ${OPUS_SEARCH_PATHS})
+
+find_library(OPUSFILE_LIBRARY
+	NAMES opusfile
+	PATH_SUFFIXES lib
+	PATHS ${OPUS_SEARCH_PATHS})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Opus DEFAULT_MSG OPUS_LIBRARY OPUSFILE_LIBRARY OPUS_INCLUDE_DIR)
+
+mark_as_advanced(OPUS_INCLUDE_DIR OPUS_LIBRARY OPUSFILE_LIBRARY)

--- a/src/modules/sound/lullaby/OpusDecoder.cpp
+++ b/src/modules/sound/lullaby/OpusDecoder.cpp
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2006-2026 LOVE Development Team
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ **/
+
+#include "OpusDecoder.h"
+
+#include "common/Exception.h"
+
+namespace love
+{
+namespace sound
+{
+namespace lullaby
+{
+
+static int opusRead(void *_stream, unsigned char *ptr, int sizeToRead)
+{
+	auto stream = (Stream *) _stream;
+	return stream->read(ptr, sizeToRead);
+}
+
+static int opusSeek(void *_stream, opus_int64 offset, int whence)
+{
+	auto stream = (Stream *) _stream;
+	auto origin = Stream::SEEKORIGIN_BEGIN;
+
+	switch (whence)
+	{
+		case SEEK_SET:
+			origin = Stream::SEEKORIGIN_BEGIN;
+			break;
+		case SEEK_CUR:
+			origin = Stream::SEEKORIGIN_CURRENT;
+			break;
+		case SEEK_END:
+			origin = Stream::SEEKORIGIN_END;
+			break;
+		default:
+			break;
+	};
+
+	return stream->seek(offset, origin) ? 0 : -1;
+}
+
+static opus_int64 opusTell(void *_stream)
+{
+	auto stream = (Stream *) _stream;
+	return (opus_int64) stream->tell();
+}
+/**
+ * END CALLBACK FUNCTIONS
+ **/
+
+OpusDecoder::OpusDecoder(Stream *stream, int bufferSize)
+: Decoder(stream, bufferSize)
+, duration(-2.0)
+{
+	OpusFileCallbacks callbacks = {};
+	callbacks.close = NULL;
+	callbacks.seek  = opusSeek;
+	callbacks.read  = opusRead;
+	callbacks.tell  = opusTell;
+
+	constexpr size_t LOOKUP_SIZE = 512;
+
+	std::vector<uint8> data(LOOKUP_SIZE);
+	uint8 *dataPtr = data.data();
+	stream->read(dataPtr, LOOKUP_SIZE);
+
+	handle = op_open_callbacks(stream, &callbacks, dataPtr, LOOKUP_SIZE, NULL);
+
+	if (handle == NULL)
+		throw love::Exception("Could not read Opus bitstream");
+
+	opusHead = op_head(handle, -1);
+}
+
+OpusDecoder::~OpusDecoder()
+{
+	op_free(handle);
+}
+
+love::sound::Decoder *OpusDecoder::clone()
+{
+	StrongRef<Stream> s(stream->clone(), Acquire::NORETAIN);
+	return new OpusDecoder(s, bufferSize);
+}
+
+int OpusDecoder::decode()
+{
+	int size = 0;
+
+	while (size < bufferSize)
+	{
+		// libopus wants and returns per-channel samples
+		int samplesToRead = (bufferSize - size) / (getChannelCount() * sizeof(opus_int16));
+		if (samplesToRead <= 0)	break;
+
+		int result = op_read(handle, (opus_int16 *)((char *)buffer + size), samplesToRead, NULL);
+
+		if (result == OP_HOLE)
+			continue;
+		else if (result <= OP_EREAD)
+			return -1;
+		else if (result == 0)
+		{
+			eof = true;
+			break;
+		}
+		else if (result > 0)
+		{
+			int bytesRead = result * getChannelCount() * sizeof(opus_int16);
+			size += bytesRead;
+		}
+	}
+
+	return size;
+}
+
+bool OpusDecoder::seek(double s)
+{
+	int result = op_pcm_seek(handle, (ogg_int64_t)(s * 48000.0));
+
+	if (result == 0)
+	{
+		eof = false;
+		return true;
+	}
+
+	return false;
+}
+
+bool OpusDecoder::rewind()
+{
+	int result = op_raw_seek(handle, 0);
+
+	if (result == 0)
+	{
+		eof = false;
+		return true;
+	}
+
+	return false;
+}
+
+bool OpusDecoder::isSeekable()
+{
+	return (op_seekable(handle) != 0);
+}
+
+int OpusDecoder::getChannelCount() const
+{
+	return opusHead->channel_count;
+}
+
+int OpusDecoder::getBitDepth() const
+{
+	return 16;
+}
+
+int OpusDecoder::getSampleRate() const
+{
+	// return (int) opusHead->input_sample_rate;
+	return 48000;
+}
+
+double OpusDecoder::getDuration()
+{
+	// Only calculate the duration if we haven't done so already.
+	if (duration == -2.0)
+	{
+		duration = op_pcm_total(handle, -1);
+
+		if (duration == OP_EINVAL || duration < 0.0)
+			duration = -1.0;
+		else
+			duration = duration / 48000.0;
+	}
+
+	return duration;
+}
+
+} // lullaby
+} // sound
+} // love

--- a/src/modules/sound/lullaby/OpusDecoder.h
+++ b/src/modules/sound/lullaby/OpusDecoder.h
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2006-2026 LOVE Development Team
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ **/
+
+#ifndef LOVE_SOUND_LULLABY_OPUS_DECODER_H
+#define LOVE_SOUND_LULLABY_OPUS_DECODER_H
+
+// LOVE
+#include "common/Stream.h"
+#include "sound/Decoder.h"
+
+// opus
+#include <opus/opus.h>
+#include <opus/opusfile.h>
+
+namespace love
+{
+namespace sound
+{
+namespace lullaby
+{
+
+class OpusDecoder : public Decoder
+{
+public:
+	OpusDecoder(Stream *stream, int bufferSize);
+	~OpusDecoder();
+
+	love::sound::Decoder *clone() override;
+	int decode() override;
+	bool seek(double s) override;
+	bool rewind() override;
+	bool isSeekable() override;
+	int getChannelCount() const override;
+	int getBitDepth() const override;
+	int getSampleRate() const override;
+	double getDuration() override;
+
+private:
+	OggOpusFile *handle;
+	const OpusHead *opusHead;
+	double duration;
+}; // OpusDecoder
+
+} // lullaby
+} // sound
+} // love
+
+#endif // LOVE_SOUND_LULLABY_OPUS_DECODER_H

--- a/src/modules/sound/lullaby/Sound.cpp
+++ b/src/modules/sound/lullaby/Sound.cpp
@@ -27,6 +27,7 @@
 
 #include "ModPlugDecoder.h"
 #include "VorbisDecoder.h"
+#include "OpusDecoder.h"
 #include "WaveDecoder.h"
 #include "FLACDecoder.h"
 #include "MP3Decoder.h"
@@ -73,6 +74,7 @@ sound::Decoder *Sound::newDecoder(Stream *stream, int bufferSize)
 		DecoderImplFor<WaveDecoder>(),
 		DecoderImplFor<FLACDecoder>(),
 		DecoderImplFor<VorbisDecoder>(),
+		DecoderImplFor<OpusDecoder>(),
 #ifdef LOVE_SUPPORT_COREAUDIO
 		DecoderImplFor<CoreAudioDecoder>(),
 #endif


### PR DESCRIPTION
- [ ] I confirm that all code in this pull request is either authored by me or has proper attribution and licensing included, and that this pull request does not include any output from generative AI / LLM tools.

An LLM was used for debugging and figuring CMake. The code was authored by me based on OpusFile documentation and VorbisDecoder.

## Description
Adds OpusDecoder, based largely on VorbisDecoder. Opus streams with more than 2 channels are untested. Won't compile with Megasource as it needs `libopus` added to it (one of the reasons this is a draft).

## Related Issues
Fixes #1319.
