### PR TITLE
unclamped gain #2336

### DIFF
--- a/src/modules/audio/null/Source.cpp
+++ b/src/modules/audio/null/Source.cpp
@@ -176,6 +176,9 @@ float Source::getMinVolume() const
 
 void Source::setMaxVolume(float volume)
 {
+	#ifndef AL_SOFT_gain_clamp_ex
+		volume = std::min(volume, 1.0f);
+	#endif
 	this->maxVolume = volume;
 }
 

--- a/src/modules/audio/wrap_Source.cpp
+++ b/src/modules/audio/wrap_Source.cpp
@@ -273,7 +273,7 @@ int w_Source_setVolumeLimits(lua_State *L)
 	Source *t = luax_checksource(L, 1);
 	float vmin = (float)luaL_checknumber(L, 2);
 	float vmax = (float)luaL_checknumber(L, 3);
-	if (vmin < .0f || vmin > 1.f || vmax < .0f || vmax > 1.f)
+	if (vmin < .0f || vmin > 1.f || vmax < .0f)
 		return luaL_error(L, "Invalid volume limits: [%f:%f]. Must be in [0:1]", vmin, vmax);
 	t->setMinVolume(vmin);
 	t->setMaxVolume(vmax);

--- a/testing/tests/audio.lua
+++ b/testing/tests/audio.lua
@@ -87,10 +87,10 @@ love.test.audio.Source = function(test)
   test:assertFalse(stereo:isPlaying(), 'check stopped playing')
 
   -- check volume limits
-  stereo:setVolumeLimits(0.1, 0.5)
+  stereo:setVolumeLimits(0.1, 5.5)
   local min, max = stereo:getVolumeLimits()
   test:assertRange(min, 0.1, 0.2, 'check min limit')
-  test:assertRange(max, 0.5, 0.6, 'check max limit')
+  test:assertRange(max, 5.5, 5.6, 'check max limit')
 
   -- check setting volume
   stereo:setVolume(1)


### PR DESCRIPTION
- [yes ] I confirm that all code in this pull request is either authored by me or has proper attribution and licensing included, and that this pull request does not include any output from generative AI / LLM tools.

## Description

- Simply removed a check in w_Source_setVolumeLimits which prevented the user from setting vmax to a number higher then 1
- Tested in custom love2d project on Ubuntu Linux and confirmed that the backend properly bumps the audio above 1 (when the limit is set higher)
- Modified test suite to test for the case where the volume limit is higher then 1

## Related Issues
Feature #2336 
https://github.com/love2d/love/issues/2336