### PR TITLE
refactor: allow sound even iphone is unmuted

### DIFF
--- a/src/common/ios.mm
+++ b/src/common/ios.mm
@@ -376,13 +376,18 @@ bool setAudioMixWithOthers(bool mixEnabled)
 {
 	@autoreleasepool
 	{
-		NSString *category = AVAudioSessionCategorySoloAmbient;
-		NSError *err;
+		AVAudioSession *session = [AVAudioSession sharedInstance];
+		NSString *category = AVAudioSessionCategoryPlayback;
+		NSUInteger options = 0;
+		NSError *err = nil;
 
 		if (mixEnabled)
-			category = AVAudioSessionCategoryAmbient;
+			options = AVAudioSessionCategoryOptionMixWithOthers;
 
-		bool success = [[AVAudioSession sharedInstance] setCategory:category error:&err];
+		bool success = [session setCategory:category
+							mode:AVAudioSessionModeDefault
+							options:options
+							error:&err];
 		if (!success)
 			NSLog(@"Error in AVAudioSession setCategory: %@", [err localizedDescription]);
 


### PR DESCRIPTION
- [x] I confirm that all code in this pull request is either authored by me or has proper attribution and licensing included, and that this pull request does not include any output from generative AI / LLM tools.

## Description
- Game audio now works even iPhone user is muted;
- The iOS layer was using the “ambient/solo ambient” session path, which is exactly the path that the mute switch can silence. I switched that to a playback session that stays audible under the user’s app volume settings.

## Related Issues
N/A
