### PR TITLE
Fix readback of shader performing image atomics pulling outdated data.

### DIFF
--- a/src/modules/graphics/metal/Graphics.h
+++ b/src/modules/graphics/metal/Graphics.h
@@ -141,6 +141,8 @@ public:
 
 	static Graphics *getInstance() { return graphicsInstance; }
 
+	void waitForFence(love::graphics::Texture *texture, id<MTLBlitCommandEncoder> encoder);
+
 	id<MTLDevice> device;
 
 private:
@@ -211,6 +213,9 @@ private:
 	void applyRenderState(id<MTLRenderCommandEncoder> renderEncoder, VertexAttributesID attributesID);
 	bool applyShaderUniforms(id<MTLComputeCommandEncoder> encoder, love::graphics::Shader *shader);
 	bool applyShaderUniforms(id<MTLRenderCommandEncoder> renderEncoder, love::graphics::Shader *shader, Texture *maintex);
+	bool updateFences(love::graphics::Shader *shader);
+	void updateFences(id<MTLComputeCommandEncoder> encoder, love::graphics::Shader *shader);
+	void updateFences(id<MTLRenderCommandEncoder> encoder, love::graphics::Shader *shader);
 
 	id<MTLCommandQueue> commandQueue;
 
@@ -251,6 +256,7 @@ private:
 
 	bool isVMDevice;
 
+	std::unordered_map<love::graphics::Texture *, id<MTLFence>> textureFences;
 }; // Graphics
 
 } // metal

--- a/src/modules/graphics/metal/Graphics.mm
+++ b/src/modules/graphics/metal/Graphics.mm
@@ -614,6 +614,8 @@ void Graphics::submitCommandBuffer(SubmitType type)
 		[commandBuffer commit];
 		commandBuffer = nil;
 	}
+
+	textureFences.clear();
 }
 
 void Graphics::submitAllEncoders(SubmitType type)
@@ -1234,6 +1236,60 @@ bool Graphics::applyShaderUniforms(id<MTLRenderCommandEncoder> renderEncoder, lo
 	return allWritableVariablesSet;
 }
 
+void Graphics::updateFences(id<MTLComputeCommandEncoder> encoder, love::graphics::Shader *shader)
+{
+	Shader *s = (Shader *)shader;
+	for (const Shader::TextureBinding &b : s->getTextureBindings())
+	{
+		uint8 texindex = b.textureStages[SHADERSTAGE_COMPUTE];
+		love::graphics::Texture *sampler = b.samplerTexture;
+		if (texindex != LOVE_UINT8_MAX && (b.access & Shader::ACCESS_WRITE) != 0 && sampler != nil)
+		{
+			auto iter = textureFences.find(sampler);
+			if (iter == textureFences.end())
+			{
+				iter = textureFences.emplace(sampler, [device newFence]).first;
+			}
+
+			id<MTLFence> fence = iter->second;
+			[encoder updateFence:fence];
+		}
+	}
+}
+
+void Graphics::updateFences(id<MTLRenderCommandEncoder> encoder, love::graphics::Shader *shader)
+{
+	Shader *s = (Shader *)shader;
+	for (const Shader::TextureBinding &b : s->getTextureBindings())
+	{
+		uint8 texindex = b.textureStages[SHADERSTAGE_COMPUTE];
+		love::graphics::Texture *sampler = b.samplerTexture;
+		if (texindex != LOVE_UINT8_MAX && (b.access & Shader::ACCESS_WRITE) != 0 && sampler != nil)
+		{
+			auto iter = textureFences.find(sampler);
+			if (iter == textureFences.end())
+			{
+				iter = textureFences.emplace(sampler, [device newFence]).first;
+			}
+
+			id<MTLFence> fence = iter->second;
+			[encoder updateFence:fence
+					 afterStages:(MTLRenderStageVertex | MTLRenderStageFragment)];
+		}
+	}
+}
+
+void Graphics::waitForFence(love::graphics::Texture *texture, id<MTLBlitCommandEncoder> encoder)
+{ @autoreleasepool {
+	auto iter = textureFences.find(texture);
+	if (iter != textureFences.end())
+	{
+		id<MTLFence> fence = iter->second;
+		[encoder waitForFence:fence];
+		textureFences.erase(iter);
+	}
+}}
+
 static void setVertexBuffers(id<MTLRenderCommandEncoder> encoder, love::graphics::Shader *shader, const BufferBindings *buffers, Graphics::RenderEncoderBindings &bindings)
 {
 	Shader *s = (Shader *)shader;
@@ -1286,6 +1342,8 @@ void Graphics::draw(const DrawCommand &cmd)
 				  instanceCount:cmd.instanceCount];
 	}
 
+	updateFences(encoder, Shader::current);
+
 	++drawCalls;
 }}
 
@@ -1325,6 +1383,8 @@ void Graphics::draw(const DrawIndexedCommand &cmd)
 					 indexBufferOffset:cmd.indexBufferOffset
 						 instanceCount:cmd.instanceCount];
 	}
+
+	updateFences(encoder, Shader::current);
 
 	++drawCalls;
 }}
@@ -1422,6 +1482,8 @@ void Graphics::drawQuads(int start, int count, VertexAttributesID attributesID, 
 				advanceVertexOffsets(attributes, bufferscopy, quadcount * 4);
 		}
 	}
+
+	updateFences(encoder, Shader::current);
 }}
 
 bool Graphics::dispatch(love::graphics::Shader *s, int x, int y, int z)
@@ -1445,6 +1507,8 @@ bool Graphics::dispatch(love::graphics::Shader *s, int x, int y, int z)
 
 	[computeEncoder dispatchThreadgroups:MTLSizeMake(x, y, z)
 				   threadsPerThreadgroup:MTLSizeMake(tX, tY, tZ)];
+	
+	updateFences(computeEncoder, s);
 
 	return true;
 }}
@@ -1471,6 +1535,8 @@ bool Graphics::dispatch(love::graphics::Shader *s, love::graphics::Buffer *indir
 	[computeEncoder dispatchThreadgroupsWithIndirectBuffer:getMTLBuffer(indirectargs)
 									  indirectBufferOffset:argsoffset
 									 threadsPerThreadgroup:MTLSizeMake(tX, tY, tZ)];
+
+	updateFences(computeEncoder, s);
 
 	return true;
 }

--- a/src/modules/graphics/metal/Texture.mm
+++ b/src/modules/graphics/metal/Texture.mm
@@ -360,7 +360,8 @@ void Texture::copyFromBuffer(love::graphics::Buffer *source, size_t sourceoffset
 
 void Texture::copyToBuffer(love::graphics::Buffer *dest, int slice, int mipmap, const Rect &rect, size_t destoffset, int destwidth, size_t size)
 { @autoreleasepool {
-	id<MTLBlitCommandEncoder> encoder = Graphics::getInstance()->useBlitEncoder();
+	auto gfx = Graphics::getInstance();
+	id<MTLBlitCommandEncoder> encoder = gfx->useBlitEncoder();
 	id<MTLBuffer> buffer = (__bridge id<MTLBuffer>)(void *) dest->getHandle();
 
 	size_t rowSize = 0;
@@ -374,6 +375,8 @@ void Texture::copyToBuffer(love::graphics::Buffer *dest, int slice, int mipmap, 
 	MTLBlitOption options = MTLBlitOptionNone;
 	if (isPixelFormatDepthStencil(format))
 		options = MTLBlitOptionDepthFromDepthStencil;
+
+	gfx->waitForFence(this, encoder);
 
 	[encoder copyFromTexture:texture
 				 sourceSlice:texType == TEXTURE_VOLUME ? 0 : slice

--- a/testing/tests/graphics.lua
+++ b/testing/tests/graphics.lua
@@ -1087,6 +1087,66 @@ love.test.graphics.Shader = function(test)
   else
     test:assertTrue(true, "skip feature test")
   end
+
+  if love.graphics.getSupported().glsl4 then
+    -- On Metal, readback of an image's values after atomic operations are performed on it could be incorrect
+    local imageBuffer = love.graphics.newTexture(512, 512, { format = "r32i", canvas = true, computewrite = true })
+    local shader = love.graphics.newComputeShader([[
+      layout (local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+      #ifdef GL_ES
+        precision highp float;
+      #endif
+
+      layout (r32i) restrict uniform highp iimage2D ImageBuffer;
+
+      uniform int IncrementValue;
+
+      void computemain()
+      {
+        ivec2 size = imageSize(ImageBuffer);
+        ivec2 coordinate = ivec2(gl_GlobalInvocationID.xy);
+
+        if (!(coordinate.x < size.x && coordinate.y < size.y))
+        {
+          return;
+        }
+
+        imageAtomicAdd(ImageBuffer, coordinate, IncrementValue);
+      }
+    ]])
+    shader:send("ImageBuffer", imageBuffer)
+
+    local rng = love.math.newRandomGenerator(0)
+    local currentValue = 0
+    for _ = 1, 100 do
+      local value = rng:random(-16, 16)
+      local iterations = rng:random(2, 8)
+
+      shader:send("IncrementValue", value)
+
+      local x, y, z = shader:getLocalThreadgroupSize()
+      love.graphics.dispatchThreadgroups(
+        shader,
+        math.max(math.ceil(imageBuffer:getWidth() / x), 1),
+        math.max(math.ceil(imageBuffer:getHeight() / y), 1),
+        math.max(math.ceil(iterations / z), 1)
+      )
+
+      local pixelX = rng:random(0, imageBuffer:getWidth() - 1)
+      local pixelY = rng:random(0, imageBuffer:getHeight() - 1)
+
+      local imageData = love.graphics.readbackTexture(imageBuffer, nil, nil, pixelX, pixelY, 1, 1)
+
+      local nextValue = currentValue + value * iterations
+      local readbackValue = imageData:getInt32(0)
+
+      test:assertEquals(nextValue, readbackValue, "expect readback value to equal next value")
+      currentValue = nextValue
+    end
+  else
+    test:assertTrue(true, "skip atomic readback test")
+  end
 end
 
 


### PR DESCRIPTION
- [x] I confirm that all code in this pull request is either authored by me or has proper attribution and licensing included, and that this pull request does not include any output from generative AI / LLM tools.

## Description

After performing a readback immediately after a compute dispatch using image atomics, oftentimes a readback call (whether immediate or async) directly after the dispatch would be incorrect and have outdated (e.g., the previous dispatch's) data.

**This only affected Metal platforms.**

This example fails on https://github.com/love2d/love/commit/48b5e1303d92abe59dec07a835116e956def7e30, but passes in this branch.

```lua
local ffi = require "ffi"

local test = {}

local function execute()
    local value = love.math.random(-16, 16)
    local iterations = love.math.random(1, 8)

    test.shader:send("test_Image", test.image)
    test.shader:send("test_IncrementValue", value)

    local x, y, z = test.shader:getLocalThreadgroupSize()
    love.graphics.dispatchThreadgroups(
        test.shader,
        math.max(math.ceil(test.image:getWidth() / x), 1),
        math.max(math.ceil(test.image:getHeight() / y), 1),
        math.max(math.ceil(iterations / z), 1)
    )

    local pixelX, pixelY =
        love.math.random(0, test.image:getWidth() - 1),
        love.math.random(0, test.image:getHeight() - 1)

    --- @type love.ImageData
    local imageData =
        love.graphics.readbackTexture(test.image, nil, nil, pixelX, pixelY, 1, 1)
    test.value = test.value + value * iterations
    test.readback = tonumber(ffi.cast("int32_t *", imageData:getFFIPointer())[0])
end

function love.load()
    test.image = love.graphics.newTexture(
        love.graphics.getWidth(),
        love.graphics.getHeight(),
        { format = "r32i", computewrite = true }
    )

    test.shader = love.graphics.newComputeShader [[
        layout (local_size_x = 8, local_size_y = 8, local_size_z = 1) in;

        layout (r32i) restrict uniform iimage2D test_Image;

        uniform int test_IncrementValue;

        void computemain()
        {
            ivec2 size = imageSize(test_Image);
            ivec2 coordinate = ivec2(gl_GlobalInvocationID.xy);

            if (!(coordinate.x < size.x && coordinate.y < size.y))
            {
                return;
            }

            imageAtomicAdd(test_Image, coordinate, test_IncrementValue);
        }
    ]]
    
    test.value = 0
    execute()
end

function love.keypressed(key, scan, isRepeat)
    if scan == "space" and not isRepeat then
        execute()
    end
end

function love.draw()
    if test.value == test.readback then
        love.graphics.setColor(0, 1, 0, 1)
    else
        love.graphics.setColor(1, 0, 0, 1)
    end

    love.graphics.print(("expected value = %d, readback value = %d"):format(test.value, test.readback))
end
```

`test.value` and `test.readback` will probably not be the same value.

I added a test to cover this scenario. The test fails on `main`, but passes locally with this PR.

## Related Issues
See discussion on Discord: https://discord.com/channels/329400828920070144/516361887840075812/1541795336333434933
